### PR TITLE
Bug Fix: Compatibility with custom models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
   - conda update -q conda
   - conda info -a
 install:
-  - wget -q https://raw.githubusercontent.com/qiime2/environment-files/master/latest/staging/qiime2-latest-py36-linux-conda.yml
-  - conda env create -q -n test-env --file qiime2-latest-py36-linux-conda.yml
+  - wget -q https://raw.githubusercontent.com/qiime2/environment-files/master/2020.8/release/qiime2-2020.8-py36-linux-conda.yml
+  - conda env create -q -n test-env --file qiime2-2020.8-py36-linux-conda.yml
   - source activate test-env
   - conda install -q pytest-cov
   - conda install -q -c conda-forge xgboost

--- a/q2_mlab/_benchmark.py
+++ b/q2_mlab/_benchmark.py
@@ -1,8 +1,61 @@
 import pandas as pd
 import biom
+import pkg_resources
 from skbio.stats.distance import DistanceMatrix
 from .learningtask import RegressionTask, ClassificationTask
 
+
+def iter_entry_points():
+    for entry_point in pkg_resources.iter_entry_points(
+            group='q2_mlab.models'):
+        yield entry_point
+
+
+def _unit_benchmark(
+    table: biom.Table,
+    metadata: pd.Series,
+    algorithm: str,
+    params: str,
+    distance_matrix: DistanceMatrix = None,
+    n_repeats: int = 3,
+) -> pd.DataFrame:
+
+    # Add any custom algorithms from entry points
+    for entry_point in iter_entry_points():
+        name = entry_point.name
+        method = entry_point.load()
+        print(name, method)
+        print(method._estimator_type)
+        # Check what algorithm type the custom method/pipeline has
+        if method._estimator_type == "regressor":
+            RegressionTask.algorithms.update({name: method})
+        if method._estimator_type == "classifier":
+            ClassificationTask.algorithms.update({name: method})
+        if (method._estimator_type not in ["regressor", "classifier"]):
+            msg = (
+                "Linked custom model is not a valid estimator type. "
+                "Check attribute _estimator_type. "
+                "Valid types are: classifier, regressor"
+            )
+            raise TypeError(msg)
+
+    if algorithm in RegressionTask.algorithms:
+        worker = RegressionTask(
+            table, metadata, algorithm, params, n_repeats, distance_matrix
+        )
+    elif algorithm in ClassificationTask.algorithms:
+        worker = ClassificationTask(
+            table, metadata, algorithm, params, n_repeats, distance_matrix
+        )
+    else:
+        raise ValueError(algorithm + " is not an accepted algorithm")
+
+    for train_index, test_index in worker.splits:
+        worker.cv_fold(train_index, test_index)
+
+    results_table = worker.tabularize()
+
+    return results_table, worker.best_model, worker.best_accuracy
 
 def unit_benchmark(
     table: biom.Table,
@@ -23,31 +76,3 @@ def unit_benchmark(
     )
 
     return results_table
-
-
-def _unit_benchmark(
-    table: biom.Table,
-    metadata: pd.Series,
-    algorithm: str,
-    params: str,
-    distance_matrix: DistanceMatrix = None,
-    n_repeats: int = 3,
-) -> pd.DataFrame:
-
-    if algorithm in RegressionTask.algorithms:
-        worker = RegressionTask(
-            table, metadata, algorithm, params, n_repeats, distance_matrix
-        )
-    elif algorithm in ClassificationTask.algorithms:
-        worker = ClassificationTask(
-            table, metadata, algorithm, params, n_repeats, distance_matrix
-        )
-    else:
-        raise ValueError(algorithm + " is not an accepted algorithm")
-
-    for train_index, test_index in worker.splits:
-        worker.cv_fold(train_index, test_index)
-
-    results_table = worker.tabularize()
-
-    return results_table, worker.best_model, worker.best_accuracy

--- a/q2_mlab/_preprocess.py
+++ b/q2_mlab/_preprocess.py
@@ -156,7 +156,7 @@ def preprocess(
     print("Generating Distance Matrices...")
     for metric in ["jaccard", "braycurtis", "jensenshannon", "aitchison"]:
         beta_results = beta(
-            table=filtered_rarefied_table, metric=metric, n_jobs=n_jobs
+            table=filtered_rarefied_table, metric=metric, threads=n_jobs
         )
         results += beta_results
     if phylogeny:

--- a/q2_mlab/_preprocess.py
+++ b/q2_mlab/_preprocess.py
@@ -156,7 +156,7 @@ def preprocess(
     print("Generating Distance Matrices...")
     for metric in ["jaccard", "braycurtis", "jensenshannon", "aitchison"]:
         beta_results = beta(
-            table=filtered_rarefied_table, metric=metric, threads=n_jobs
+            table=filtered_rarefied_table, metric=metric, n_jobs=n_jobs
         )
         results += beta_results
     if phylogeny:
@@ -165,7 +165,7 @@ def preprocess(
                 table=filtered_rarefied_table,
                 phylogeny=phylogeny,
                 metric=metric,
-                n_jobs=n_jobs,
+                threads=n_jobs,
             )
             results += beta_phylo_results
     else:

--- a/q2_mlab/learningtask.py
+++ b/q2_mlab/learningtask.py
@@ -2,7 +2,6 @@ import json
 import numpy as np
 import pandas as pd
 import time
-import pkg_resources
 from abc import ABC
 
 # CV Methods
@@ -48,11 +47,6 @@ from sklearn.linear_model import ElasticNet, Lasso
 class LearningTask(ABC):
     algorithms = {}
 
-    def iter_entry_points(cls):
-        for entry_point in pkg_resources.iter_entry_points(
-                group='q2_mlab.models'):
-            yield entry_point
-
     def __init__(
         self,
         table,
@@ -62,11 +56,6 @@ class LearningTask(ABC):
         n_repeats,
         distance_matrix=None,
     ):
-        # Add any custom algorithms from entry points
-        for entry_point in self.iter_entry_points():
-            name = entry_point.name
-            method = entry_point.load()
-            self.algorithms.update({name: method})
 
         self.learner = self.algorithms[algorithm]
         print(params)
@@ -169,8 +158,7 @@ class ClassificationTask(LearningTask):
 
         # Start timing
         start = time.process_time()
-        model = self.learner()
-        model.set_params(**self.params)
+        model = self.learner(**self.params)
         model.fit(X_train, y_train)
         y_pred = model.predict(X_test)
         # End timimg

--- a/q2_mlab/tests/test_preprocessing.py
+++ b/q2_mlab/tests/test_preprocessing.py
@@ -62,9 +62,12 @@ class PreprocessingTests(TestPluginBase):
         self.assertTrue(str(results[5].type) == 'DistanceMatrix')
         self.assertTrue(str(results[6].type) == 'DistanceMatrix')
 
-        phylo_dm_string = "DistanceMatrix % Properties('phylogenetic')"
-        self.assertTrue(str(results[7].type) == phylo_dm_string)
-        self.assertTrue(str(results[8].type) == phylo_dm_string)
+        phylo_dm_strings = ["DistanceMatrix % Properties('phylogenetic')",
+                            "DistanceMatrix"]
+        # QIIME2 2020.8 changes beta_phylogenetic to a Pipeline and
+        # changes the resulting artifact type to "DistanceMatrix"
+        self.assertTrue(str(results[7].type) in phylo_dm_strings)
+        self.assertTrue(str(results[8].type) in phylo_dm_strings)
 
         self.assertEqual(
             results[0].view(biom.Table).shape[1],


### PR DESCRIPTION
We include a check to iterate through entry points and add any custom models from the entry point group 'q2_mlab.models' into the appropriate LearningTask's algorithms. 

Fixing a bug where the custom algorithm passed is not recognized as a valid algorithm, this PR moves that entry point logic to before any checks for the algorithm's availability in (Regression/Classification)Task.