### PR TITLE
Small fixes

### DIFF
--- a/q2_mlab/_benchmark.py
+++ b/q2_mlab/_benchmark.py
@@ -24,8 +24,6 @@ def _unit_benchmark(
     for entry_point in iter_entry_points():
         name = entry_point.name
         method = entry_point.load()
-        print(name, method)
-        print(method._estimator_type)
         # Check what algorithm type the custom method/pipeline has
         if method._estimator_type == "regressor":
             RegressionTask.algorithms.update({name: method})
@@ -56,6 +54,7 @@ def _unit_benchmark(
     results_table = worker.tabularize()
 
     return results_table, worker.best_model, worker.best_accuracy
+
 
 def unit_benchmark(
     table: biom.Table,

--- a/q2_mlab/_parameters.py
+++ b/q2_mlab/_parameters.py
@@ -18,7 +18,7 @@ class ParameterGrids:
     hidden_layer_sizes = [10, 50, 100, 200, 500]
     for r in range(1, 4):
         for comb in combinations(hidden_layer_sizes, r):
-            mlp_hidden_layer_grids.append(hidden_layer_sizes)
+            mlp_hidden_layer_grids.append(comb)
 
     # Notes:
     # fit_intercept - set to True in all cases due to statistical properties

--- a/q2_mlab/learningtask.py
+++ b/q2_mlab/learningtask.py
@@ -284,7 +284,7 @@ class RegressionTask(LearningTask):
         self.results["RUNTIME"][curr_indices] = runtime
         self.results["CV_IDX"][curr_indices] = self.cv_idx
         self.results["Y_PRED"][curr_indices] = y_pred
-        self.results["Y_TRUE"][curr_indices] = y_test_ids
+        self.results["Y_TRUE"][curr_indices] = y_test
         self.results["SAMPLE_ID"][curr_indices] = y_test_ids
 
         if not self.contains_nan(y_pred):

--- a/q2_mlab/learningtask.py
+++ b/q2_mlab/learningtask.py
@@ -24,7 +24,10 @@ from sklearn.metrics import (
 from sklearn.pipeline import Pipeline
 from sklearn.neighbors import KNeighborsRegressor, KNeighborsClassifier
 from sklearn.linear_model import (
-    RidgeClassifier, Ridge, LogisticRegression, LinearRegression,
+    RidgeClassifier,
+    Ridge,
+    LogisticRegression,
+    LinearRegression,
 )
 from xgboost import XGBRegressor, XGBClassifier
 from sklearn.svm import LinearSVR, LinearSVC
@@ -57,6 +60,7 @@ class ModelFactory:
         class SpecificModel(model_class):
             def __init__(self, **kwargs):
                 super().__init__(**outer_kwargs, **kwargs)
+
         return SpecificModel
 
 
@@ -64,22 +68,22 @@ class ModelFactory:
 # `Lasso`'s classification equivalent is `LogisticRegression` with
 # `penalty='l1'`. You can use ModelFactory.get_model to create Estimator
 # classes that set specific parameters.
-LogisticRegressionLasso = ModelFactory.get_model(LogisticRegression,
-                                                 penalty='l1')
-LogisticRegressionElasticNet = ModelFactory.get_model(LogisticRegression,
-                                                      penalty='elasticnet')
-RadialSVR = ModelFactory.get_model(SVR, kernel='rbf')
-SigmoidSVR = ModelFactory.get_model(SVR, kernel='sigmoid')
-RadialSVC = ModelFactory.get_model(SVC, kernel='rbf')
-SigmoidSVC = ModelFactory.get_model(SVC, kernel='sigmoid')
-LGBMRegressorGBDT = ModelFactory.get_model(LGBMRegressor,
-                                           boosting_type='gbdt')
-LGBMRegressorRF = ModelFactory.get_model(LGBMRegressor,
-                                         boosting_type='rf')
-LGBMClassifierGBDT = ModelFactory.get_model(LGBMClassifier,
-                                            boosting_type='gbdt')
-LGBMClassifierRF = ModelFactory.get_model(LGBMClassifier,
-                                          boosting_type='rf')
+LogisticRegressionLasso = ModelFactory.get_model(
+    LogisticRegression, penalty="l1"
+)
+LogisticRegressionElasticNet = ModelFactory.get_model(
+    LogisticRegression, penalty="elasticnet"
+)
+RadialSVR = ModelFactory.get_model(SVR, kernel="rbf")
+SigmoidSVR = ModelFactory.get_model(SVR, kernel="sigmoid")
+RadialSVC = ModelFactory.get_model(SVC, kernel="rbf")
+SigmoidSVC = ModelFactory.get_model(SVC, kernel="sigmoid")
+LGBMRegressorGBDT = ModelFactory.get_model(LGBMRegressor, boosting_type="gbdt")
+LGBMRegressorRF = ModelFactory.get_model(LGBMRegressor, boosting_type="rf")
+LGBMClassifierGBDT = ModelFactory.get_model(
+    LGBMClassifier, boosting_type="gbdt"
+)
+LGBMClassifierRF = ModelFactory.get_model(LGBMClassifier, boosting_type="rf")
 
 
 class LearningTask(ABC):
@@ -118,11 +122,21 @@ class LearningTask(ABC):
         self.best_model = None
 
         self.results = {}
-        self.results["CV_IDX"] = np.zeros(self.table_size, dtype=int)
-        self.results["SAMPLE_ID"] = np.zeros(self.table_size, dtype=object)
-        self.results["Y_PRED"] = np.zeros(self.table_size, dtype=float)
-        self.results["Y_TRUE"] = np.zeros(self.table_size, dtype=object)
-        self.results["RUNTIME"] = np.zeros(self.table_size, dtype=float)
+        self.results["CV_IDX"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=int
+        )
+        self.results["SAMPLE_ID"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=object
+        )
+        self.results["Y_PRED"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=float
+        )
+        self.results["Y_TRUE"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=object
+        )
+        self.results["RUNTIME"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=float
+        )
 
         # Check for sample id agreement between table and metadata
         if list(metadata.index) != list(table.ids()):
@@ -185,11 +199,21 @@ class ClassificationTask(LearningTask):
 
         for n in list(range(self.n_classes)):
             colname = "PROB_CLASS_" + str(n)
-            self.results[colname] = np.zeros(self.table_size, dtype=float)
-        self.results["ACCURACY"] = np.zeros(self.table_size, dtype=float)
-        self.results["AUPRC"] = np.zeros(self.table_size, dtype=float)
-        self.results["AUROC"] = np.zeros(self.table_size, dtype=float)
-        self.results["F1"] = np.zeros(self.table_size, dtype=float)
+            self.results[colname] = np.full(
+                self.table_size, fill_value=np.nan, dtype=float
+            )
+        self.results["ACCURACY"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=float
+        )
+        self.results["AUPRC"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=float
+        )
+        self.results["AUROC"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=float
+        )
+        self.results["F1"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=float
+        )
 
     def cv_fold(self, train_index, test_index):
         X_train, X_test = self.X[train_index], self.X[test_index]
@@ -305,9 +329,15 @@ class RegressionTask(LearningTask):
         )
         self.splits = kfold.split(X=self.X, y=self.y)
 
-        self.results["MAE"] = np.zeros(self.table_size, dtype=float)
-        self.results["RMSE"] = np.zeros(self.table_size, dtype=float)
-        self.results["R2"] = np.zeros(self.table_size, dtype=float)
+        self.results["MAE"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=float
+        )
+        self.results["RMSE"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=float
+        )
+        self.results["R2"] = np.full(
+            self.table_size, fill_value=np.nan, dtype=float
+        )
 
     def cv_fold(self, train_index, test_index):
         X_train, X_test = self.X[train_index], self.X[test_index]

--- a/q2_mlab/tests/test_unit_benchmark.py
+++ b/q2_mlab/tests/test_unit_benchmark.py
@@ -188,7 +188,7 @@ class UnitBenchmarkTests(TestPluginBase):
         )
 
         self.assertTrue(best_model)
-        self.assertEquals(results['ACCURACY'].max(), best_accuracy)
+        self.assertEqual(results['ACCURACY'].max(), best_accuracy)
 
     def testKNNDistanceMatrix(self):
         pass

--- a/q2_mlab/tests/test_unit_benchmark.py
+++ b/q2_mlab/tests/test_unit_benchmark.py
@@ -191,7 +191,7 @@ class UnitBenchmarkTests(TestPluginBase):
         self.assertTrue(best_model)
         self.assertEqual(results['ACCURACY'].max(), best_accuracy)
 
-    def testResultTable(self):
+    def test_result_table(self):
 
         n_features = 10
         n_samples = 30

--- a/q2_mlab/tests/test_unit_benchmark.py
+++ b/q2_mlab/tests/test_unit_benchmark.py
@@ -222,7 +222,7 @@ class UnitBenchmarkTests(TestPluginBase):
         for sampleid in results.SAMPLE_ID:
             self.assertTrue(sampleid in sample_ids)
         for y in results.Y_TRUE:
-            self.assertTrue(y in np.arange(n_features*n_samples))
+            self.assertTrue(y in list(test_data.flatten()))
 
         # Test Classification table
         results, _, _ = q2_mlab._unit_benchmark(
@@ -232,11 +232,10 @@ class UnitBenchmarkTests(TestPluginBase):
             params=self.svc_params,
             n_repeats=1
         )
-
         for sampleid in results.SAMPLE_ID:
             self.assertTrue(sampleid in sample_ids)
         for y in results.Y_TRUE:
-            self.assertTrue(y in np.arange(n_features*n_samples))
+            self.assertTrue(y in list(test_data.flatten()))
 
     def testKNNDistanceMatrix(self):
         pass


### PR DESCRIPTION
Removes noisy print statements from unit_benchmark, and fixes a bug in RegressionTask where the sample_ids were saved in the y_true column of the results table.
Only affects the y_true column in the results table, as the list `y_test` was used directly in any calculations (RMSE). These true values correspond to the value of target variable for each sample_ID in the original dataset, so they are recoverable if we really need them.