### PR TITLE
NEW sqlalchemy tables for scores and parameters 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ target/
 *.qzv
 q2_mlab/tests/.DS_Store
 .DS_Store
+
+# PyCharm
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - conda env create -q -n test-env --file qiime2-2020.8-py36-linux-conda.yml
   - source activate test-env
   - conda install -q pytest-cov
-  - conda install -q -c conda-forge xgboost tqdm lightgbm sqlalchemy
+  - conda install -q -c conda-forge xgboost tqdm lightgbm<3 sqlalchemy
   - pip install -q flake8 coveralls
   - make install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - conda env create -q -n test-env --file qiime2-2020.8-py36-linux-conda.yml
   - source activate test-env
   - conda install -q pytest-cov
-  - conda install -q -c conda-forge xgboost tqdm lightgbm
+  - conda install -q -c conda-forge xgboost tqdm lightgbm sqlalchemy
   - pip install -q flake8 coveralls
   - make install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - conda env create -q -n test-env --file qiime2-2020.8-py36-linux-conda.yml
   - source activate test-env
   - conda install -q pytest-cov
-  - conda install -q -c conda-forge xgboost tqdm lightgbm<3 sqlalchemy
+  - conda install -q -c conda-forge xgboost tqdm 'lightgbm<3' sqlalchemy
   - pip install -q flake8 coveralls
   - make install
 script:

--- a/q2_mlab/db/__init__.py
+++ b/q2_mlab/db/__init__.py
@@ -1,0 +1,14 @@
+from .schema import (
+    RegressionScore,
+    Parameters,
+)
+
+__all__ = [
+    'maint',
+    'cli',
+    'tests',
+    'schema',
+    'mapping',
+    'RegressionScore',
+    'Parameters',
+]

--- a/q2_mlab/db/cli.py
+++ b/q2_mlab/db/cli.py
@@ -1,4 +1,6 @@
 import click
+import json
+from qiime2 import Artifact
 from q2_mlab.db.maint import (
     create as db_create,
     add_from_qza
@@ -76,9 +78,11 @@ def create(db, echo):
 )
 def add(db, echo, results_artifact, parameters, dataset, target, level,
         algorithm):
+    artifact = Artifact.load(results_artifact)
+    parameters = json.loads(parameters)
     add_from_qza(
-        artifact_path=results_artifact,
-        parameters_string=parameters,
+        artifact=artifact,
+        parameters=parameters,
         dataset=dataset,
         target=target,
         level=level,

--- a/q2_mlab/db/cli.py
+++ b/q2_mlab/db/cli.py
@@ -1,0 +1,88 @@
+import click
+from q2_mlab.db.maint import (
+    create as db_create,
+    add_from_qza
+)
+
+
+@click.group()
+def mlab_db():
+    pass
+
+
+@mlab_db.command()
+@click.option(
+    '--db',
+    help='Path to SQLite database file.',
+    type=click.Path(exists=False),
+)
+@click.option(
+    '--echo/--no-echo',
+    default=False,
+    help='Echo the database log statements',
+)
+def create(db, echo):
+    db_create(db, echo=echo)
+
+
+@mlab_db.command()
+@click.option(
+    '--db',
+    help='Path to SQLite database file.',
+    required=True,
+    type=click.Path(exists=True),
+)
+@click.option(
+    '--results-artifact',
+    help='Path to Results artifact',
+    required=True,
+    type=click.Path(exists=True),
+)
+@click.option(
+    '--algorithm',
+    help='Name of the algorithm corresponding to these results',
+    required=True,
+    type=str,
+)
+@click.option(
+    '--parameters',
+    help="JSON-formatted string corresponding to the algorithm's parameters",
+    required=True,
+    type=str,
+)
+@click.option(
+    '--dataset',
+    help='Name of the dataset corresponding to these results',
+    required=True,
+    type=str,
+)
+@click.option(
+    '--target',
+    help='Name of the target corresponding to these results',
+    required=True,
+    type=str,
+)
+@click.option(
+    '--level',
+    help='Name corresponding to the sequencing type/level used for these '
+         'results',
+    required=True,
+    type=str,
+)
+@click.option(
+    '--echo/--no-echo',
+    default=False,
+    help='Echo the database log statements',
+)
+def add(db, echo, results_artifact, parameters, dataset, target, level,
+        algorithm):
+    add_from_qza(
+        artifact_path=results_artifact,
+        parameters_string=parameters,
+        dataset=dataset,
+        target=target,
+        level=level,
+        algorithm=algorithm,
+        db_file=db,
+        echo=echo,
+    )

--- a/q2_mlab/db/maint.py
+++ b/q2_mlab/db/maint.py
@@ -1,0 +1,85 @@
+import json
+import pandas as pd
+from sqlalchemy.engine import Engine
+from sqlalchemy import create_engine as sql_create_engine
+from sqlalchemy.orm import sessionmaker
+from datetime import datetime
+from qiime2 import Artifact
+from q2_mlab.db.schema import RegressionScore, Parameters, Base
+from q2_mlab.db.mapping import remap_parameters
+from typing import Optional, Callable
+
+
+DROP_COLS = ['SAMPLE_ID', 'Y_PRED', 'Y_TRUE']
+
+
+def format_db(db_file: Optional[str] = None) -> str:
+    if db_file is not None:
+        loc = '/' + db_file
+    else:
+        # this creates an in memory database
+        loc = ''
+    return f"sqlite://{loc}"
+
+
+def create_engine(db_file: Optional[str] = None, echo=True) -> Engine:
+    engine = sql_create_engine(format_db(db_file), echo=echo)
+    return engine
+
+
+def create(db_file: Optional[str] = None, echo=True) -> Engine:
+    engine = create_engine(db_file, echo=echo)
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def add(engine: Engine, results: pd.DataFrame, parameters: dict,
+        dataset: str, target: str, level: str, algorithm: str,
+        ) -> None:
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    params = Parameters(**parameters)
+    session.add(params)
+    session.flush()
+
+    for entry in results.iterrows():
+        score = RegressionScore(datetime=datetime.now(),
+                                parameters_id=params.id,
+                                dataset=dataset,
+                                target=target,
+                                level=level,
+                                algorithm=algorithm,
+                                **entry[1],
+                                )
+        session.add(score)
+
+    session.commit()
+
+
+def add_from_qza(artifact_path: str,
+                 parameters_string: str,
+                 dataset: str,
+                 target: str,
+                 level: str,
+                 algorithm: str,
+                 db_file: Optional[str] = None,
+                 echo: bool = True,
+                 engine_creator: Callable = create_engine,
+                 ):
+
+    engine = engine_creator(db_file, echo=echo)
+
+    results = Artifact.load(artifact_path).view(pd.DataFrame)
+    # perform filtering on results (single entry per cross validation)
+    results.drop(DROP_COLS, axis=1, inplace=True)
+    results.drop_duplicates(inplace=True)
+
+    parameters = json.loads(parameters_string)
+    # remap multi-type arguments, e.g., 'max_features'
+    parameters = remap_parameters(parameters)
+
+    add(engine, results, parameters,
+        dataset=dataset, target=target, level=level, algorithm=algorithm,
+        )
+    return engine

--- a/q2_mlab/db/maint.py
+++ b/q2_mlab/db/maint.py
@@ -43,7 +43,7 @@ def add(engine: Engine, results: pd.DataFrame, parameters: dict,
 
     # check if parameters exists in db
     query = session.query(Parameters).filter_by(**parameters)
-    params = query.one_or_none()
+    params = query.first()
 
     # if no record exists with these parameters, add them to the table
     if params is None:

--- a/q2_mlab/db/maint.py
+++ b/q2_mlab/db/maint.py
@@ -49,8 +49,8 @@ def add(engine: Engine, results: pd.DataFrame, parameters: dict,
     if params is None:
         params = Parameters(**parameters)
         session.add(params)
-    params_id = params.id
     session.flush()
+    params_id = params.id
 
     # check if algorithm is valid
     valid_algorithms = RegressionTask.algorithms

--- a/q2_mlab/db/mapping.py
+++ b/q2_mlab/db/mapping.py
@@ -1,0 +1,33 @@
+import json
+
+
+def trivial_remapper(parameter, value):
+    return {parameter: value}
+
+
+def string_or_number_remapper(parameter, value):
+    if isinstance(value, str):
+        return {parameter + '_STRING': value}
+    elif isinstance(value, (int, float)):
+        return {parameter + '_NUMBER': value}
+
+
+def serialize_remapper(parameter, value):
+    return {parameter: json.dumps(value)}
+
+
+mappers = {
+    'gamma': string_or_number_remapper,
+    'hidden_layer_sizes': serialize_remapper,
+    'learning_rate': string_or_number_remapper,
+    'max_features': string_or_number_remapper,
+}
+
+
+def remap_parameters(parameters: dict, ):
+    mapped = dict()
+    for parameter, value in parameters.items():
+        remap = mappers.get(parameter, trivial_remapper)
+        mapped.update(remap(parameter, value))
+
+    return mapped

--- a/q2_mlab/db/mapping.py
+++ b/q2_mlab/db/mapping.py
@@ -10,6 +10,8 @@ def string_or_number_remapper(parameter, value):
         return {parameter + '_STRING': value}
     elif isinstance(value, (int, float)):
         return {parameter + '_NUMBER': value}
+    else:
+        return dict()
 
 
 def serialize_remapper(parameter, value):

--- a/q2_mlab/db/schema.py
+++ b/q2_mlab/db/schema.py
@@ -20,6 +20,7 @@ class Score:
     dataset = Column(String, nullable=False)
     level = Column(String, nullable=False)  # 16S, metagenomics, etc.
     target = Column(String, nullable=False)
+    artifact_uuid = Column(String, nullable=False)
     datetime = Column(DateTime)
     # could be cool to store the timedelta with Interval instead
     RUNTIME = Column(Float)

--- a/q2_mlab/db/schema.py
+++ b/q2_mlab/db/schema.py
@@ -1,0 +1,91 @@
+from sqlalchemy import (
+    Column,
+    Float,
+    String,
+    Boolean,
+    Integer,
+    DateTime,
+    ForeignKey,
+)
+
+from sqlalchemy.ext.declarative import declarative_base
+
+
+Base = declarative_base()
+
+
+class Score:
+    id = Column(Integer, primary_key=True)
+    algorithm = Column(String, nullable=False)
+    dataset = Column(String, nullable=False)
+    level = Column(String, nullable=False)  # 16S, metagenomics, etc.
+    target = Column(String, nullable=False)
+    datetime = Column(DateTime)
+    # could be cool to store the timedelta with Interval instead
+    RUNTIME = Column(Float)
+    CV_IDX = Column(Integer)
+
+
+class RegressionScore(Base, Score):
+
+    __tablename__ = 'regression'
+
+    R2 = Column(Float)
+    RMSE = Column(Float)
+    MAE = Column(Float)
+
+    parameters_id = Column(Integer, ForeignKey('parameters.id'))
+
+
+class Parameters(Base):
+    __tablename__ = 'parameters'
+
+    id = Column(Integer, primary_key=True)
+
+    # algorithm parameters
+    activation = Column(String)
+    alpha = Column(Float)
+    booster = Column(String)
+    bootstrap = Column(Boolean)
+    C = Column(Float)
+    coef0 = Column(Integer)
+    colsample_bytree = Column(Float)
+    criterion = Column(String)
+    early_stopping = Column(Boolean)
+    epsilon = Column(Float)
+    fit_intercept = Column(Boolean)
+    gamma_STRING = Column(String)
+    gamma_NUMBER = Column(Float)
+    hidden_layer_sizes = Column(String)
+    l1_ratio = Column(Float)
+    l2_regularization = Column(Float)
+    learning_rate_STRING = Column(String)
+    learning_rate_NUMBER = Column(Float)
+    loss = Column(String)
+    max_depth = Column(Integer)
+    max_features_STRING = Column(String)
+    max_features_NUMBER = Column(Float)
+    max_iter = Column(Integer)
+    max_leaf_nodes = Column(Integer)
+    max_samples = Column(Float)
+    metric = Column(String)
+    min_child_weight = Column(Float)
+    min_samples_split = Column(Float)
+    min_samples_leaf = Column(Float)
+    n_jobs = Column(Integer)
+    n_estimators = Column(Integer)
+    n_iter_no_change = Column(Integer)
+    n_neighbors = Column(Integer)
+    normalize = Column(Boolean)
+    num_leaves = Column(Integer)
+    objective = Column(String)
+    penalty = Column(String)
+    positive = Column(Boolean)
+    silent = Column(Integer)
+    solver = Column(String)
+    subsample = Column(Float)
+    tol = Column(Float)
+    random_state = Column(Integer)
+    reg_alpha = Column(Float)
+    reg_lambda = Column(Float)
+    weights = Column(String)

--- a/q2_mlab/db/tests/test_db.py
+++ b/q2_mlab/db/tests/test_db.py
@@ -103,6 +103,8 @@ class DBTestCase(unittest.TestCase):
         self.assertEqual(2, len(score_df))
         self.assertCountEqual(score_df['R2'].values.tolist(), [0.7, 0.3])
         self.assertCountEqual(score_df['RUNTIME'].values.tolist(), [3.5, 2.3])
+        print(score_df['parameters_id'])
+        self.assertEqual(score_df['parameters_id'].values.tolist(), [1, 1])
 
     def test_add_from_qza_None_parameter(self):
         format_name = "SampleData[Results]"

--- a/q2_mlab/db/tests/test_db.py
+++ b/q2_mlab/db/tests/test_db.py
@@ -1,0 +1,89 @@
+import tempfile
+import unittest
+import pandas as pd
+from qiime2 import Artifact
+from q2_mlab.db.schema import Parameters, RegressionScore
+from q2_mlab.db.maint import (
+    create,
+    add,
+    add_from_qza,
+)
+from sqlalchemy.engine import Engine
+
+
+class DBTestCase(unittest.TestCase):
+
+    def test_create_in_memory(self):
+        engine = create(echo=False)
+        self.assertIsInstance(engine, Engine)
+
+    def test_create_in_file(self):
+        fh = tempfile.NamedTemporaryFile()
+        engine = create(fh.name, echo=False)
+        self.assertIsInstance(engine, Engine)
+        fh.close()
+
+    def test_add(self):
+        engine = create(echo=False)
+        parameters = {'max_features_STRING': 'log2'}
+        results = pd.DataFrame([
+            {'CV_IDX': 0, 'RUNTIME': 3.5, 'MAE': 2.4, 'RMSE': 7.24, 'R2': 0.7},
+            {'CV_IDX': 1, 'RUNTIME': 2.3, 'MAE': 7.4, 'RMSE': 8.25, 'R2': 0.3},
+        ])
+        dataset = 'FINRISK'
+        algorithm = 'RandomForestRegressor'
+        level = 'MG'
+        target = 'AGE'
+        add(engine=engine, results=results, parameters=parameters,
+            dataset=dataset, algorithm=algorithm, level=level, target=target,
+            )
+
+    def test_add_from_qza(self):
+        fh = tempfile.NamedTemporaryFile(suffix='.qza')
+        qza_path = fh.name
+        format_name = "SampleData[Results]"
+
+        results = pd.DataFrame([
+            {'CV_IDX': 0, 'SAMPLE_ID': 'SAMPLE-1', 'Y_PRED': 4, 'Y_TRUE': 4,
+             'RUNTIME': 3.5, 'MAE': 2.4, 'RMSE': 7.24, 'R2': 0.7},
+            {'CV_IDX': 0, 'SAMPLE_ID': 'SAMPLE-2', 'Y_PRED': 5, 'Y_TRUE': 6,
+             'RUNTIME': 3.5, 'MAE': 2.4, 'RMSE': 7.24, 'R2': 0.7},
+            {'CV_IDX': 0, 'SAMPLE_ID': 'SAMPLE-3', 'Y_PRED': 5, 'Y_TRUE': 4,
+             'RUNTIME': 3.5, 'MAE': 2.4, 'RMSE': 7.24, 'R2': 0.7},
+            {'CV_IDX': 1, 'SAMPLE_ID': 'SAMPLE-1', 'Y_PRED': 4, 'Y_TRUE': 4,
+             'RUNTIME': 2.3, 'MAE': 7.4, 'RMSE': 8.25, 'R2': 0.3},
+        ])
+
+        imported_artifact = Artifact.import_data(format_name,
+                                                 results
+                                                 )
+        imported_artifact.save(qza_path)
+
+        parameters = '{"max_features": "log2", "gamma": 0.01, "normalize": '\
+                     'true}'
+
+        dataset = 'FINRISK'
+        algorithm = 'RandomForestRegressor'
+        level = 'MG'
+        target = 'AGE'
+
+        engine = add_from_qza(qza_path, parameters, dataset, target, level,
+                              algorithm,
+                              engine_creator=create,
+                              echo=False,
+                              )
+
+        param_df = pd.read_sql_table(Parameters.__tablename__, con=engine)
+        self.assertEqual(1, len(param_df))
+        self.assertListEqual(param_df['gamma_NUMBER'].values.tolist(), [0.01])
+        self.assertListEqual(param_df['max_features_STRING'].values.tolist(),
+                             ['log2'])
+
+        score_df = pd.read_sql_table(RegressionScore.__tablename__, con=engine)
+        self.assertEqual(2, len(score_df))
+        self.assertCountEqual(score_df['R2'].values.tolist(), [0.7, 0.3])
+        self.assertCountEqual(score_df['RUNTIME'].values.tolist(), [3.5, 2.3])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/q2_mlab/db/tests/test_db.py
+++ b/q2_mlab/db/tests/test_db.py
@@ -5,6 +5,7 @@ from qiime2 import Artifact
 from q2_mlab.db.schema import Parameters, RegressionScore
 from q2_mlab.db.maint import (
     create,
+    create_engine,
     add,
     add_from_qza,
 )
@@ -158,6 +159,9 @@ class DBTestCase(unittest.TestCase):
         level = 'MG'
         target = 'AGE'
 
+        fh = tempfile.NamedTemporaryFile()
+        db_file = fh.name
+
         parameters = {'bootstrap': True, 'criterion': 'mse', 'max_depth': 7,
                       'min_samples_leaf': 0.41, 'min_samples_split': 0.2,
                       'n_estimators': 100, 'n_jobs': -1, 'random_state': 2020,
@@ -167,6 +171,7 @@ class DBTestCase(unittest.TestCase):
                               dataset,
                               target,
                               level, algorithm,
+                              db_file=db_file,
                               engine_creator=create,
                               echo=False,
                               )
@@ -183,12 +188,15 @@ class DBTestCase(unittest.TestCase):
                                   dataset,
                                   target,
                                   level, algorithm,
-                                  engine_creator=create,
+                                  db_file=db_file,
+                                  engine_creator=create_engine,
                                   echo=False,
                                   )
 
         param_df = pd.read_sql_table(Parameters.__tablename__, con=engine)
         self.assertEqual(1, len(param_df))
+
+        fh.close()
 
 
 if __name__ == '__main__':

--- a/q2_mlab/db/tests/test_mapping.py
+++ b/q2_mlab/db/tests/test_mapping.py
@@ -1,0 +1,51 @@
+import unittest
+
+from q2_mlab.db.mapping import (
+    remap_parameters,
+    trivial_remapper,
+    string_or_number_remapper,
+    serialize_remapper,
+)
+
+
+class ParameterRemapTestCase(unittest.TestCase):
+    def test_trivial_remapper(self):
+        parameter = 'param'
+        value = 24
+        obs = trivial_remapper(parameter, value)
+        self.assertDictEqual({'param': 24}, obs)
+
+    def test_string_or_number_remapper(self):
+        parameter = 'param'
+        value = 24
+        obs = string_or_number_remapper(parameter, value)
+        self.assertDictEqual({'param_NUMBER': 24}, obs)
+        value = '24'
+        obs = string_or_number_remapper(parameter, value)
+        self.assertDictEqual({'param_STRING': '24'}, obs)
+
+    def test_serialize_mapper(self):
+        parameter = 'param'
+        value = [1, 3, 4]
+        obs = serialize_remapper(parameter, value)
+        exp = {"param": '[1, 3, 4]'}
+        self.assertDictEqual(exp, obs)
+
+    def test_remap_parameters(self):
+        params = {
+            'trivial': 24,
+            'gamma': 0.01,
+            'hidden_layer_sizes': [1, 3, 4],
+        }
+
+        obs = remap_parameters(params)
+        exp = {
+            'trivial': 24,
+            'gamma_NUMBER': 0.01,
+            'hidden_layer_sizes': '[1, 3, 4]',
+        }
+        self.assertDictEqual(exp, obs)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ setup(
     url="https://qiime2.org",
     entry_points={
         'qiime2.plugins': ['q2-mlab=q2_mlab.plugin_setup:plugin'],
-        'console_scripts': ['orchestrator=q2_mlab.orchestrator:cli'],
+        'console_scripts': ['orchestrator=q2_mlab.orchestrator:cli',
+                            'mlab-db=q2_mlab.db.cli:mlab_db',
+                            ],
     },
     package_data={'q2_mlab': ['assets/index.html',
                               'citations.bib',
@@ -37,6 +39,7 @@ setup(
         'jinja2',
         'tqdm',
         'biom-format',
-        'lightgbm'
+        'lightgbm',
+        'sqlalchemy',
     ]
 )


### PR DESCRIPTION
This PR adds a database module to q2-mlab, to make for convenient access to the bench-marking results.

This first pass, uses [`sqlalchemy`](https://www.sqlalchemy.org/) to create the table schemas and interact with the database. I have also exposed some convenience methods for adding rows to the database via a cli.
