### PR TITLE
Database sanity checks init

### DIFF
--- a/q2_mlab/db/sanity.py
+++ b/q2_mlab/db/sanity.py
@@ -1,0 +1,216 @@
+from enum import Enum
+from functools import partial
+import sqlalchemy
+import pandas as pd
+import logging
+from q2_mlab.db.maint import sessionmaker
+from q2_mlab.db.schema import RegressionScore, Parameters
+
+
+def _set_params(obj, args, kwargs):
+    obj.session = kwargs.pop('session', None)
+    obj.db_file = kwargs.pop('db_file', None)
+    obj.echo = kwargs.pop('echo', False)
+    return args, kwargs
+
+
+def _validate_params(obj):
+    if obj.db_file is None and obj.session is None:
+        raise ValueError("Requires keyword argument 'db_file' or 'session'")
+
+
+def _make_session(obj, sessionmaker):
+    if obj.session is None:
+        Session = sessionmaker(obj.db_file, echo=obj.echo)
+        obj.session = Session()
+    elif obj.echo:
+        raise UserWarning("Parameter 'echo' has no effect when used with "
+                          "'session'")
+
+
+class CreateSession:
+
+    def __init__(self,
+                 session_strategy=None,
+                 params_strategy=None,
+                 validation_strategy=None,
+                 ):
+        self.session = None
+        self.db_file = None
+        self.echo = None
+        self.session_strategy = None
+        self.params_strategy = None
+        self.validation_strategy = None
+
+        self.set_strategies(
+            params_strategy, session_strategy, validation_strategy
+        )
+
+    def set_strategies(self, params_strategy, session_strategy,
+                       validation_strategy):
+        if session_strategy is None:
+            session_strategy = partial(_make_session,
+                                       sessionmaker=sessionmaker)
+        if params_strategy is None:
+            params_strategy = _set_params
+        if validation_strategy is None:
+            validation_strategy = _validate_params
+        self.session_strategy = session_strategy
+        self.params_strategy = params_strategy
+        self.validation_strategy = validation_strategy
+
+    def __call__(self, func):
+
+        def func_wrapper(*args, **kwargs):
+            args, kwargs = self.params_strategy(self, args, kwargs)
+            self.validation_strategy(self)
+            self.session_strategy(self)
+            session = self.session
+            return func(*args, session, **kwargs)
+
+        return func_wrapper
+
+
+@CreateSession()
+def has_duplicate_parameters(session):
+    """
+    The `create_session` decorator guarantees that session is not None,
+    and is a valid session, instead.
+    """
+    engine = session.get_bind()
+    Parameters_columns = sqlalchemy.inspect(
+        engine
+    ).get_columns(
+        Parameters.__tablename__
+    )
+    columns = [col['name'] for col in Parameters_columns
+               if col['name'] != 'id']
+
+    all_params = pd.read_sql_table(Parameters.__tablename__, con=engine)
+
+    return any(all_params[columns].duplicated())
+
+
+@CreateSession()
+def has_duplicate_artifact_uuid(session):
+    engine = session.get_bind()
+    q = session.query(RegressionScore.artifact_uuid,
+                      RegressionScore.datetime,
+                      ).distinct()
+    df = pd.read_sql(q.statement, con=engine)
+    has_duplicates = any(df['artifact_uuid'].duplicated())
+    return has_duplicates
+
+
+@CreateSession()
+def count_duplicate_artifact_uuid(session):
+    engine = session.get_bind()
+    q = session.query(RegressionScore.artifact_uuid,
+                      RegressionScore.datetime,
+                      ).distinct()
+    df = pd.read_sql(q.statement, con=engine)
+    count = df.groupby('artifact_uuid').count()['datetime'].value_counts()
+    count.index.name = 'times_observed'
+    count.name = 'uuid_count'
+    count = pd.DataFrame(count).reset_index().T
+    return count.to_dict().values()
+
+
+class Violations(Enum):
+    DUPLICATE_PARAMETERS = 1
+    DUPLICATE_UUID = 2
+
+
+class Check:
+
+    def __init__(self, session):
+        self.session = session
+
+    def __call__(self):
+        raise NotImplementedError('Abstract Method')
+
+    def failure(self):
+        return self()
+
+    @staticmethod
+    def violation():
+        raise NotImplementedError('Abstract method')
+
+    def failure_info(self):
+        return None
+
+    @property
+    def name(self):
+        return type(self).__name__
+
+
+class NoDuplicatedParameterCheck(Check):
+    def __call__(self):
+        return has_duplicate_parameters(session=self.session)
+
+    @staticmethod
+    def violation():
+        return Violations.DUPLICATE_PARAMETERS
+
+
+class NoDuplicatedUUIDCheck(Check):
+    def __call__(self):
+        return has_duplicate_artifact_uuid(session=self.session)
+
+    def failure_info(self):
+        return count_duplicate_artifact_uuid(session=self.session)
+
+    @staticmethod
+    def violation():
+        return Violations.DUPLICATE_UUID
+
+
+DEFAULT_CHECKS = [
+    NoDuplicatedParameterCheck,
+    NoDuplicatedUUIDCheck,
+]
+
+
+class SanityChecker:
+
+    def __init__(self, checks=None, additional_info=False):
+        self.session = None
+        self.violations = set()
+        if checks is None:
+            checks = DEFAULT_CHECKS
+        self.checks = checks
+        self.additional_info = additional_info
+
+    @CreateSession()
+    def start(self, session):
+        self.session = session
+
+    def run(self, db_file=None):
+        if db_file is not None:
+            self.start(db_file=db_file)
+        for check in self.checks:
+            checker = check(session=self.session)
+            logging.info(f"Performing check: {checker.name}...")
+            if checker.failure():
+                logging.info(f"Failed {checker.name}.")
+                self.violations.add(checker.violation())
+                if self.additional_info:
+                    self.get_extra_info(checker)
+            else:
+                logging.info(f"Successful {checker.name}.")
+
+        logging.info("Finished Checks.")
+        logging.info(f"Violations: {self.violations}")
+
+    def get_extra_info(self, checker):
+        info = checker.failure_info()
+        if info is not None:
+            logging.info(f"Additional info on failed {checker.name}: {info}")
+
+
+if __name__ == "__main__":
+    import sys
+    db_file = sys.argv[1]
+    logging.getLogger().setLevel(logging.INFO)
+    checker = SanityChecker(additional_info=True)
+    checker.run(db_file=db_file)

--- a/q2_mlab/db/tests/test_sanity_tests.py
+++ b/q2_mlab/db/tests/test_sanity_tests.py
@@ -1,0 +1,219 @@
+import unittest
+from unittest.mock import MagicMock
+from datetime import datetime, timedelta
+import tempfile
+from q2_mlab.db.maint import (
+    create,
+    sessionmaker as maint_sessionmaker,
+)
+from q2_mlab.db.schema import (
+    Parameters,
+    RegressionScore,
+)
+from q2_mlab.db.sanity import (
+    CreateSession,
+    _set_params,
+    _validate_params,
+    _make_session,
+    has_duplicate_parameters,
+    has_duplicate_artifact_uuid,
+    count_duplicate_artifact_uuid,
+)
+
+
+class CreateSessionTestCase(unittest.TestCase):
+
+    def test_new_CreateSession_with_mocks(self):
+        def mock_set_params(obj, args, kwargs):
+            obj.foo = args[0]
+            obj.bar = kwargs.pop('bar')
+            return (), kwargs
+
+        def mock_validate_strategy(obj):
+            return True
+
+        def mock_make_session(obj):
+            obj.session = {'foo': obj.foo, 'bar': obj.bar}
+
+        @CreateSession(
+            session_strategy=mock_make_session,
+            params_strategy=mock_set_params,
+            validation_strategy=mock_validate_strategy
+        )
+        def f(session):
+            return session
+
+        exp = {'foo': 7.25, 'bar': '2019'}
+        obs = f(7.25, bar='2019')
+        self.assertDictEqual(exp, obs)
+
+    def test_set_params(self):
+        obj = MagicMock()
+        input_args = ('foo', 'bar', 'baz')
+        input_kwargs = {
+            'db_file': 'some_file',
+            'echo': True,
+            'other_kwarg': True,
+        }
+        args, kwargs = _set_params(obj, input_args, input_kwargs)
+
+        self.assertIsNone(obj.session)
+        self.assertEqual(obj.db_file, 'some_file')
+        self.assertEqual(obj.echo, True)
+        self.assertTupleEqual(input_args, args)
+        self.assertDictEqual({'other_kwarg': True}, kwargs)
+
+    def test_validate_params(self):
+        obj = MagicMock()
+        obj.db_file = None
+        obj.session = None
+        with self.assertRaises(ValueError):
+            _validate_params(obj)
+
+        obj.db_file = 'some file'
+        obj.session = None
+        _validate_params(obj)
+
+    def test_make_session(self):
+
+        def mock_sessionmaker(db_file, echo):
+            class Session(dict):
+                def __init__(self):
+                    super().__init__()
+                    self.update({'db_file': db_file, 'echo': echo})
+            return Session
+
+        obj = MagicMock()
+        obj.session = None
+        obj.db_file = 'db_filename'
+        obj.echo = 8.25
+
+        exp = {'db_file': 'db_filename', 'echo': 8.25}
+
+        _make_session(obj, mock_sessionmaker)
+
+        self.assertDictEqual(exp, obj.session)
+
+    def test_create_session_integration_defaults(self):
+        fh = tempfile.NamedTemporaryFile()
+        fp = fh.name
+        engine = create(db_file=fp, echo=False)
+        Session = maint_sessionmaker(engine=engine)
+        sess = Session()
+        params = Parameters(alpha=1)
+        sess.add(params)
+        sess.commit()
+
+        @CreateSession()
+        def some_session_function(session):
+            results = session.query(Parameters).all()
+            return len(results)
+
+        obs = some_session_function(db_file=fp, echo=False)
+        self.assertEqual(1, obs)
+
+        obs = some_session_function(session=sess, echo=False)
+        self.assertEqual(1, obs)
+
+
+class SanityCheckTestCases(unittest.TestCase):
+
+    def setUp(self):
+        self.db_fh = tempfile.NamedTemporaryFile()
+        fp = self.db_fh.name
+        engine = create(db_file=fp, echo=False)
+        Session = maint_sessionmaker(engine=engine)
+        self.session = Session()
+        self.boilerplate = {
+            'algorithm': 'TestRegressor',
+            'dataset': 'TestDataset',
+            'level': 'TestLevel',
+            'target': 'TestTarget',
+        }
+
+    def tearDown(self):
+        self.db_fh.close()
+
+    def test_has_duplicate_parameters(self):
+        params = Parameters(alpha=1)
+        self.session.add(params)
+        self.session.commit()
+
+        finds_dup = has_duplicate_parameters(session=self.session)
+        self.assertFalse(finds_dup)
+
+        new_params = Parameters(alpha=1)
+        self.session.add(new_params)
+        self.session.commit()
+        finds_dup = has_duplicate_parameters(session=self.session)
+        self.assertTrue(finds_dup)
+
+    def test_has_duplicate_artifact_uuid(self):
+        time01 = datetime.now()
+        score01 = RegressionScore(**self.boilerplate,
+                                  artifact_uuid='id1',
+                                  datetime=time01
+                                  )
+        self.session.add(score01)
+        score02 = RegressionScore(**self.boilerplate,
+                                  artifact_uuid='id1',
+                                  datetime=time01
+                                  )
+        self.session.add(score02)
+        score03 = RegressionScore(**self.boilerplate,
+                                  artifact_uuid='id2',
+                                  datetime=time01
+                                  )
+        self.session.add(score03)
+        self.session.commit()
+        finds_dup = has_duplicate_artifact_uuid(session=self.session)
+        self.assertFalse(finds_dup)
+
+        time02 = time01 + timedelta(seconds=1)
+        score04 = RegressionScore(**self.boilerplate,
+                                  artifact_uuid='id1',
+                                  datetime=time02,
+                                  )
+        self.session.add(score04)
+        self.session.commit()
+        finds_dup = has_duplicate_artifact_uuid(session=self.session)
+        self.assertTrue(finds_dup)
+
+    def test_count_uuid(self):
+        time01 = datetime.now()
+        score01 = RegressionScore(**self.boilerplate,
+                                  artifact_uuid='id1',
+                                  datetime=time01
+                                  )
+        self.session.add(score01)
+        score02 = RegressionScore(**self.boilerplate,
+                                  artifact_uuid='id1',
+                                  datetime=time01
+                                  )
+        self.session.add(score02)
+        score03 = RegressionScore(**self.boilerplate,
+                                  artifact_uuid='id2',
+                                  datetime=time01
+                                  )
+        self.session.add(score03)
+        score04 = RegressionScore(**self.boilerplate,
+                                  artifact_uuid='id3',
+                                  datetime=time01
+                                  )
+        self.session.add(score04)
+        time02 = time01 + timedelta(seconds=1)
+        score04 = RegressionScore(**self.boilerplate,
+                                  artifact_uuid='id1',
+                                  datetime=time02,
+                                  )
+        self.session.add(score04)
+        self.session.commit()
+        count_dup = count_duplicate_artifact_uuid(session=self.session)
+        exp = [{'times_observed': 1, 'uuid_count': 2},
+               {'times_observed': 2, 'uuid_count': 1},
+               ]
+        self.assertCountEqual(exp, count_dup)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Depends on #21 

Adds some light checks for a database, after inserting records.

Checks include:
- Ensuring that no parameters sets have been duplicated in the `Parameters` table
- Ensuring that no artifact uuid has been inserted into `RegressionScore` at multiple times.

The `SanityCheck` module is also extensible to arbitrary checks by implementing a `Check` class and doing something like:
```
checker = SanityChecker(checks=DEFAULT_CHECKS + [CustomCheck])
checker.run(db_file='path/to/some/db.sqlite3')
``` 
