### PR TITLE
Orchestrator cli bypass and repeated jobs FIX

### DIFF
--- a/q2_mlab/__init__.py
+++ b/q2_mlab/__init__.py
@@ -13,7 +13,7 @@ from .learningtask import LearningTask, ClassificationTask, RegressionTask
 from ._type import Target, Results
 from ._format import ResultsDirectoryFormat, ResultsFormat
 from ._parameters import ParameterGrids
-from .orchestrator import _orchestrate
+from .orchestrator import orchestrate_hyperparameter_search
 
 __version__ = get_versions()["version"]
 
@@ -23,7 +23,7 @@ __all__ = [
     "preprocess",
     "unit_benchmark",
     "_unit_benchmark",
-    "_orchestrate",
+    "orchestrate_hyperparameter_search",
     "ResultsDirectoryFormat",
     "ResultsFormat",
     "Target",

--- a/q2_mlab/__init__.py
+++ b/q2_mlab/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "preprocess",
     "unit_benchmark",
     "_unit_benchmark",
-    "_orchestrate"
+    "_orchestrate",
     "ResultsDirectoryFormat",
     "ResultsFormat",
     "Target",

--- a/q2_mlab/__init__.py
+++ b/q2_mlab/__init__.py
@@ -13,6 +13,7 @@ from .learningtask import LearningTask, ClassificationTask, RegressionTask
 from ._type import Target, Results
 from ._format import ResultsDirectoryFormat, ResultsFormat
 from ._parameters import ParameterGrids
+from .orchestrator import _orchestrate
 
 __version__ = get_versions()["version"]
 
@@ -22,6 +23,7 @@ __all__ = [
     "preprocess",
     "unit_benchmark",
     "_unit_benchmark",
+    "_orchestrate"
     "ResultsDirectoryFormat",
     "ResultsFormat",
     "Target",

--- a/q2_mlab/orchestrator.py
+++ b/q2_mlab/orchestrator.py
@@ -8,14 +8,15 @@ from sklearn.model_selection import ParameterGrid
 from jinja2 import Environment, FileSystemLoader
 from q2_mlab import RegressionTask, ClassificationTask, ParameterGrids
 
+
 def orchestrate_hyperparameter_search(
     dataset,
     preparation,
     target,
     algorithm,
     base_dir,
-    dataset_path = None,
-    metadata_path = None,
+    dataset_path=None,
+    metadata_path=None,
     repeats=3,
     ppn=1,
     memory=32,
@@ -26,6 +27,34 @@ def orchestrate_hyperparameter_search(
     force=False,
     dry=False,
 ):
+    """
+    Creates files and file structures necessary for a hyperparameter search
+    in q2_mlab and returns paths to those files, which include the job script,
+    list of hyperparameter sets, and some info about the search.
+    Orchestrator does not enforce anything about the dataset, metadata, and
+    target and assumes these are given from Preprocessing or similar steps.
+
+            Parameters:
+                    dataset (str): Name of dataset
+                    preparation (str): Name of data type/preparation (e.g. 16S)
+                    target (str): Name of the target variable in the metadata
+                    algorithm (str): Valid algorithm included in q2_mlab
+                    base_dir (str): The directory in which create the file structure.
+                    dataset_path (str): Specify exact path to dataset, if it cannot be assumed. Default=None
+                    metadata_path (str): Specify exact path to metadata, if it cannot be assumed. Default=None
+                    repeats (int): Number of CV repeats. Default=3
+                    ppn: Processors per node for job script. Default=1
+                    memory: GB of memory for job script.Default=32
+                    wall: Walltime in hours for job script. Default=50
+                    chunk_size: DNumber of params to run in one job for job script. Default=100
+                    randomize: Randomly shuffle the order of the hyperparameter list. Default=True
+                    reduced: If a reduced parameter grid is available, run the reduced grid. Default=False
+                    force: Overwrite existing results. Default=False
+                    dry: Perform a dry run without writing files. Default=False
+
+            Returns:
+                    binary_sum (str): Binary string of the sum of a and b
+    """
     classifiers = set(RegressionTask.algorithms.keys())
     regressors = set(ClassificationTask.algorithms.keys())
     valid_algorithms = classifiers.union(regressors)
@@ -41,8 +70,8 @@ def orchestrate_hyperparameter_search(
             algorithm_parameters = ParameterGrids.get_reduced(ALGORITHM)
         except KeyError:
             print(
-                f'{ALGORITHM} does not have a reduced grid implemented grid '
-                'in mlab.ParameterGrids'
+                f"{ALGORITHM} does not have a reduced grid implemented grid "
+                "in mlab.ParameterGrids"
             )
             raise
 
@@ -51,8 +80,8 @@ def orchestrate_hyperparameter_search(
             algorithm_parameters = ParameterGrids.get(ALGORITHM)
         except KeyError:
             print(
-                f'{ALGORITHM} does not have a grid implemented in '
-                'mlab.ParameterGrids'
+                f"{ALGORITHM} does not have a grid implemented in "
+                "mlab.ParameterGrids"
             )
             raise
 
@@ -69,12 +98,15 @@ def orchestrate_hyperparameter_search(
         TABLE_FP = dataset_path
     else:
         TABLE_FP = path.join(
-            base_dir, dataset, preparation, target, "filtered_rarefied_table.qza"
+            base_dir,
+            dataset,
+            preparation,
+            target,
+            "filtered_rarefied_table.qza",
         )
     if not path.exists(TABLE_FP):
         raise FileNotFoundError(
-            "Table was not found at the expected path: "
-            + TABLE_FP
+            "Table was not found at the expected path: " + TABLE_FP
         )
 
     if metadata_path:
@@ -85,13 +117,10 @@ def orchestrate_hyperparameter_search(
         )
     if not path.exists(METADATA_FP):
         raise FileNotFoundError(
-            "Metadata was not found at the expected path: "
-            + TABLE_FP
+            "Metadata was not found at the expected path: " + TABLE_FP
         )
 
-    RESULTS_DIR = path.join(
-        base_dir, dataset, preparation, target, ALGORITHM
-    )
+    RESULTS_DIR = path.join(base_dir, dataset, preparation, target, ALGORITHM)
     if not path.isdir(RESULTS_DIR):
         makedirs(RESULTS_DIR)
 
@@ -103,7 +132,7 @@ def orchestrate_hyperparameter_search(
     params_list = [json.dumps(param_dict) for param_dict in params]
     PARAMS_FP = path.join(RESULTS_DIR, ALGORITHM + "_parameters.txt")
     N_PARAMS = len(params_list)
-    N_CHUNKS = math.ceil(N_PARAMS/CHUNK_SIZE)
+    N_CHUNKS = math.ceil(N_PARAMS / CHUNK_SIZE)
     REMAINDER = N_PARAMS % CHUNK_SIZE
 
     random.seed(2021)
@@ -112,10 +141,10 @@ def orchestrate_hyperparameter_search(
 
     mlab_dir = path.dirname(path.abspath(__file__))
     env = Environment(
-        loader=FileSystemLoader(path.join(mlab_dir, 'templates'))
+        loader=FileSystemLoader(path.join(mlab_dir, "templates"))
     )
-    job_template = env.get_template('array_job_template.sh')
-    info_template = env.get_template('info.txt')
+    job_template = env.get_template("array_job_template.sh")
+    info_template = env.get_template("info.txt")
 
     output_from_job_template = job_template.render(
         JOB_NAME=JOB_NAME,
@@ -138,93 +167,93 @@ def orchestrate_hyperparameter_search(
         CHUNK_SIZE=CHUNK_SIZE,
         N_PARAMS=N_PARAMS,
         REMAINDER=REMAINDER,
-        N_CHUNKS=N_CHUNKS
+        N_CHUNKS=N_CHUNKS,
     )
 
     output_script = path.join(
-        base_dir,
-        dataset,
-        "_".join([preparation, target, ALGORITHM]) + ".sh"
+        base_dir, dataset, "_".join([preparation, target, ALGORITHM]) + ".sh"
     )
 
     info_doc = path.join(
         base_dir,
         dataset,
-        "_".join([preparation, target, ALGORITHM]) + "_info.txt"
+        "_".join([preparation, target, ALGORITHM]) + "_info.txt",
     )
 
     if dry:
         print(output_from_job_template)
         print("##########################")
-        print("Number of parameters: " + str(len(params_list)))
+        print(f"Number of parameters: {len(params_list)}")
         print(f"Max number of jobs with chunk size {CHUNK_SIZE}: {N_CHUNKS}")
         print(f"Will save info to: {info_doc}")
         print(f"Will save params to: {PARAMS_FP}")
         print(f"Will save script to: {output_script}")
     else:
         with open(info_doc, "w") as fh:
-                fh.write(output_from_info_template)
-        with open(PARAMS_FP, 'w') as fh:
+            fh.write(output_from_info_template)
+        with open(PARAMS_FP, "w") as fh:
             for i, p in enumerate(params_list, 1):
-                fh.write(str(i).zfill(8)+"\t"+p+"\n")
+                fh.write(str(i).zfill(8) + "\t" + p + "\n")
         with open(output_script, "w") as fh:
             fh.write(output_from_job_template)
-    
+
     return output_script, PARAMS_FP, info_doc
 
 
 @click.command()
-@click.argument('dataset')
-@click.argument('preparation')
-@click.argument('target')
-@click.argument('algorithm')
+@click.argument("dataset")
+@click.argument("preparation")
+@click.argument("target")
+@click.argument("algorithm")
 @click.option(
-    '--base_dir', '-b',
+    "--base_dir",
+    "-b",
     help="Directory to search for datasets in",
-    required=True
+    required=True,
 )
 @click.option(
-    '--repeats', '-r',
+    "--repeats",
+    "-r",
     default=3,
     help="Number of CV repeats",
 )
 @click.option(
-    '--ppn',
+    "--ppn",
     default=1,
     help="Processors per node for job script",
 )
 @click.option(
-    '--memory',
+    "--memory",
     default=32,
     help="GB of memory for job script",
 )
 @click.option(
-    '--wall',
+    "--wall",
     default=50,
     help="Walltime in hours for job script",
 )
 @click.option(
-    '--chunk_size',
+    "--chunk_size",
     default=100,
     help="Number of params to run in one job for job script",
 )
 @click.option(
-    '--randomize/--no-randomize',
+    "--randomize/--no-randomize",
     default=True,
     help="Randomly shuffle the order of the hyperparameter list",
 )
 @click.option(
-    '--reduced/--no-reduced',
+    "--reduced/--no-reduced",
     default=False,
     help="If a reduced parameter grid is available, run the reduced grid.",
 )
 @click.option(
-    '--force/--no-force',
+    "--force/--no-force",
     default=False,
     help="Overwrite existing results.",
 )
 @click.option(
-    '--dry/--no-dry',
+    "--dry/--wet",
     default=False,
     help="Perform a dry run without writing files.",
 )
@@ -244,7 +273,7 @@ def cli(
     force,
     dry,
 ):
-    _orchestrate(
+    orchestrate_hyperparameter_search(
         dataset,
         preparation,
         target,
@@ -258,9 +287,9 @@ def cli(
         randomize,
         reduced,
         force,
-        dry
+        dry,
     )
-    
+
 
 if __name__ == "__main__":
     cli()

--- a/q2_mlab/orchestrator.py
+++ b/q2_mlab/orchestrator.py
@@ -78,7 +78,7 @@ def _orchestrate(
         )
 
     if metadata_path:
-        METADATA_FP = dataset_path
+        METADATA_FP = metadata_path
     else:
         METADATA_FP = path.join(
             base_dir, dataset, preparation, target, "filtered_metadata.qza"

--- a/q2_mlab/orchestrator.py
+++ b/q2_mlab/orchestrator.py
@@ -161,9 +161,7 @@ def _orchestrate(
         print("Will save info to: " + info_doc)
         print("Will save params to: " + PARAMS_FP)
         print("Will save script to: " + output_script)
-
     else:
-
         with open(info_doc, "w") as fh:
                 fh.write(output_from_info_template)
         with open(PARAMS_FP, 'w') as fh:
@@ -173,6 +171,8 @@ def _orchestrate(
                 i += 1
         with open(output_script, "w") as fh:
             fh.write(output_from_job_template)
+    
+    return output_script, PARAMS_FP, info_doc
 
 
 @click.command()

--- a/q2_mlab/orchestrator.py
+++ b/q2_mlab/orchestrator.py
@@ -8,7 +8,7 @@ from sklearn.model_selection import ParameterGrid
 from jinja2 import Environment, FileSystemLoader
 from q2_mlab import RegressionTask, ClassificationTask, ParameterGrids
 
-def _orchestrate(
+def orchestrate_hyperparameter_search(
     dataset,
     preparation,
     target,
@@ -157,18 +157,16 @@ def _orchestrate(
         print(output_from_job_template)
         print("##########################")
         print("Number of parameters: " + str(len(params_list)))
-        print(f"Max number of jobs with chunk size {CHUNK_SIZE}: " + str(N_CHUNKS))
-        print("Will save info to: " + info_doc)
-        print("Will save params to: " + PARAMS_FP)
-        print("Will save script to: " + output_script)
+        print(f"Max number of jobs with chunk size {CHUNK_SIZE}: {N_CHUNKS}")
+        print(f"Will save info to: {info_doc}")
+        print(f"Will save params to: {PARAMS_FP}")
+        print(f"Will save script to: {output_script}")
     else:
         with open(info_doc, "w") as fh:
                 fh.write(output_from_info_template)
         with open(PARAMS_FP, 'w') as fh:
-            i = 1
-            for p in params_list:
-                fh.write(str(i).zfill(4)+"\t"+p+"\n")
-                i += 1
+            for i, p in enumerate(params_list, 1):
+                fh.write(str(i).zfill(8)+"\t"+p+"\n")
         with open(output_script, "w") as fh:
             fh.write(output_from_job_template)
     
@@ -226,7 +224,7 @@ def _orchestrate(
     help="Overwrite existing results.",
 )
 @click.option(
-    '--dry/--no-force',
+    '--dry/--no-dry',
     default=False,
     help="Perform a dry run without writing files.",
 )

--- a/q2_mlab/templates/array_job_template.sh
+++ b/q2_mlab/templates/array_job_template.sh
@@ -86,6 +86,7 @@ do
 
     # Only skip execution if results exist and we aren't forcing it.
     if [[ ${RESULTS_EXIST} = true && ${FORCE} = false ]]
+    then
         echo $RESULTS already exists, execution skipped
     else
         qiime mlab unit-benchmark --i-table {{ TABLE_FP }} \

--- a/q2_mlab/templates/array_job_template.sh
+++ b/q2_mlab/templates/array_job_template.sh
@@ -49,6 +49,12 @@ max_size="$(wc -l <${input})"
 max_n_chunks=$((($max_size/$chunk_size)+1))
 offset=$(($chunk_size * $PBS_ARRAYID))
 
+# If PBS_ARRAYID is > max_n_chunks, then exit
+if [ ${PBS_ARRAYID} -gt ${max_n_chunks} ]
+then
+    exit 0
+fi
+
 # If we are on the last possible chunk, set its size
 # to the number of remaining params
 if [ ${PBS_ARRAYID} = ${max_n_chunks} ]

--- a/q2_mlab/templates/info.txt
+++ b/q2_mlab/templates/info.txt
@@ -1,2 +1,2 @@
-parameters_fp, parameter_space_size, chunk_size, remainder, n_chunks
-{{ PARAMS_FP }}, {{ N_PARAMS }}, {{ CHUNK_SIZE }}, {{ REMAINDER }}, {{ N_CHUNKS }}
+parameters_fp,parameter_space_size,chunk_size,remainder,n_chunks
+{{ PARAMS_FP }},{{ N_PARAMS }},{{ CHUNK_SIZE }},{{ REMAINDER }},{{ N_CHUNKS }}

--- a/q2_mlab/tests/test_orchestrator.py
+++ b/q2_mlab/tests/test_orchestrator.py
@@ -3,7 +3,7 @@ import os
 from q2_mlab import _orchestrate
 
 
-class OrchestratorTests((unittest.TestCase)):
+class OrchestratorTests(unittest.TestCase):
 
     def setUp(self):
         self.TEST_DIR = os.path.split(__file__)[0]
@@ -15,15 +15,47 @@ class OrchestratorTests((unittest.TestCase)):
         )
 
     def testDryRun(self):
+
         print(__file__)
         print(os.getcwd())
-        _orchestrate(
-            dataset="imsms_test",
-            preparation="16S",
-            target="reported-antibiotic-usage",
-            algorithm="LinearSVC",
+
+        target = "reported-antibiotic-usage"
+        dataset = "imsms_test"
+        prep = "16S"
+        alg = "LinearSVC"
+
+        script_fp, params_fp, run_info_fp = _orchestrate(
+            dataset=dataset,
+            preparation=prep,
+            target=target,
+            algorithm=alg,
             base_dir=self.TEST_DIR,
             dataset_path=self.dataset_file,
             metadata_path=self.metadata_file,
             dry=True
+        )
+
+        print(script_fp, params_fp, run_info_fp)
+        self.assertEqual(
+            script_fp, 
+            os.path.join(
+                self.TEST_DIR,
+                f"{dataset}/{prep}_{target}_{alg}.sh"
+            )
+        )
+        expected = f"{dataset}/{prep}/{target}/{alg}/{alg}_parameters.txt"
+        self.assertEqual(
+            params_fp, 
+            os.path.join(
+                self.TEST_DIR,
+                expected
+            )
+        )
+        expected = f"{dataset}/{prep}_{target}_{alg}_info.txt"
+        self.assertEqual(
+            run_info_fp, 
+            os.path.join(
+                self.TEST_DIR,
+                expected
+            )
         )

--- a/q2_mlab/tests/test_orchestrator.py
+++ b/q2_mlab/tests/test_orchestrator.py
@@ -3,21 +3,17 @@ import os
 import shutil
 import subprocess
 import pandas as pd
-from q2_mlab import _orchestrate
+from q2_mlab import orchestrate_hyperparameter_search
 from pandas.testing import assert_frame_equal
 
 
-
 class OrchestratorTests(unittest.TestCase):
-
     def setUp(self):
         self.dataset = "dset_test"
         self.TEST_DIR = os.path.split(__file__)[0]
-        self.dataset_file = os.path.join(
-            self.TEST_DIR, "data/table.qza"
-        )
+        self.dataset_file = os.path.join(self.TEST_DIR, "data/table.qza")
 
-        # The metadata doesn't matter here, as mlab will only accept 
+        # The metadata doesn't matter here, as mlab will only accept
         # SampleData[Target] artifacts from preprocessing.
         self.metadata_file = os.path.join(
             self.TEST_DIR, "data/sample-metadata.tsv"
@@ -28,7 +24,11 @@ class OrchestratorTests(unittest.TestCase):
         prep = "16S"
         alg = "LinearSVR"
 
-        self.script_fp, self.params_fp, self.run_info_fp = _orchestrate(
+        (
+            self.script_fp,
+            self.params_fp,
+            self.run_info_fp,
+        ) = orchestrate_hyperparameter_search(
             dataset=dataset,
             preparation=prep,
             target=target,
@@ -37,27 +37,33 @@ class OrchestratorTests(unittest.TestCase):
             dataset_path=self.dataset_file,
             metadata_path=self.metadata_file,
             chunk_size=20,
-            dry=False
+            dry=False,
         )
 
-        # Make a runnable test script, removing TORQUE job info
+        # Make a runnable bash script for testing:
+        # We remove the first 43 lines from the job script as they contain
+        # only #PBS directives and unused environment variables such as
+        # $PBS_O_WORKDIR and $PBS_NODEFILE.
         self.test_script = os.path.splitext(self.script_fp)[0] + "_test.sh"
         with open(self.script_fp) as f:
-            # Keep last 49 lines
-            keeplines = f.readlines()[-49:]
+            keeplines = f.readlines()[43:]
             with open(self.test_script, "w") as out:
                 for line in keeplines:
                     out.write(line)
         subprocess.run(["chmod", "755", self.test_script])
-    
+
     def tearDown(self):
-        if (self.script_fp and os.path.exists(self.script_fp)):
-            os.remove(self.script_fp)
-        if (self.params_fp and os.path.exists(self.params_fp)):
-            os.remove(self.params_fp)
-        if (self.run_info_fp and os.path.exists(self.run_info_fp)):
-            os.remove(self.run_info_fp)
-        
+        # Remove files we generated.
+        files_generated = [
+            self.script_fp,
+            self.params_fp,
+            self.run_info_fp,
+            self.test_script,
+        ]
+        for file in files_generated:
+            if file and os.path.exists(file):
+                os.remove(file)
+
         # Remove the directory structure created by Orchestrator
         if os.path.exists(os.path.join(self.TEST_DIR, self.dataset)):
             shutil.rmtree(os.path.join(self.TEST_DIR, self.dataset))
@@ -69,7 +75,7 @@ class OrchestratorTests(unittest.TestCase):
         prep = "16S"
         alg = "LinearSVR"
 
-        script_fp, params_fp, run_info_fp = _orchestrate(
+        script_fp, params_fp, run_info_fp = orchestrate_hyperparameter_search(
             dataset=dataset,
             preparation=prep,
             target=target,
@@ -77,32 +83,19 @@ class OrchestratorTests(unittest.TestCase):
             base_dir=self.TEST_DIR,
             dataset_path=self.dataset_file,
             metadata_path=self.metadata_file,
-            dry=True
+            dry=True,
         )
 
         self.assertEqual(
-            script_fp, 
+            script_fp,
             os.path.join(
-                self.TEST_DIR,
-                f"{dataset}/{prep}_{target}_{alg}.sh"
-            )
+                self.TEST_DIR, f"{dataset}/{prep}_{target}_{alg}.sh"
+            ),
         )
         expected = f"{dataset}/{prep}/{target}/{alg}/{alg}_parameters.txt"
-        self.assertEqual(
-            params_fp, 
-            os.path.join(
-                self.TEST_DIR,
-                expected
-            )
-        )
+        self.assertEqual(params_fp, os.path.join(self.TEST_DIR, expected))
         expected = f"{dataset}/{prep}_{target}_{alg}_info.txt"
-        self.assertEqual(
-            run_info_fp, 
-            os.path.join(
-                self.TEST_DIR,
-                expected
-            )
-        )
+        self.assertEqual(run_info_fp, os.path.join(self.TEST_DIR, expected))
 
     def testRun(self):
 
@@ -110,34 +103,37 @@ class OrchestratorTests(unittest.TestCase):
         self.assertTrue(os.path.exists(self.params_fp))
         self.assertTrue(os.path.exists(self.run_info_fp))
 
-        expected_run_info = [{
-            "parameters_fp": self.params_fp,
-            "parameter_space_size": 112,
-            "chunk_size": 20, 
-            "remainder": 12,
-            "n_chunks": 6,
-        }]
+        expected_run_info = [
+            {
+                "parameters_fp": self.params_fp,
+                "parameter_space_size": 112,
+                "chunk_size": 20,
+                "remainder": 12,
+                "n_chunks": 6,
+            }
+        ]
         expected_run_info_df = pd.DataFrame.from_records(expected_run_info)
         returned_run_info_df = pd.read_csv(self.run_info_fp)
         assert_frame_equal(
-            expected_run_info_df,
-            returned_run_info_df,
-            check_dtype=False
+            expected_run_info_df, returned_run_info_df, check_dtype=False
         )
+
+        # This is a space-efficient way to count lines
+        # Each line in params_fp is one parameter set
         returned_num_params = -1
         with open(self.params_fp) as f:
             returned_num_params = sum(1 for line in f)
         self.assertEqual(112, returned_num_params)
 
     def testInvalidJobArrayID(self):
-        
+
         # Test invalid array ids
         os.environ["PBS_ARRAYID"] = "7"
         completed_process = subprocess.run(
             f"{self.test_script}",
             shell=True,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
         )
         self.assertEqual(completed_process.returncode, 0)
         print(completed_process)
@@ -147,13 +143,13 @@ class OrchestratorTests(unittest.TestCase):
             f"{self.test_script}",
             shell=True,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
         )
         self.assertEqual(completed_process.returncode, 0)
         print(completed_process)
 
     def testValidJobArrayID(self):
-        # Since the metadata provided is not SampleData[Target], 
+        # Since the metadata provided is not SampleData[Target],
         # we expect q2_mlab to throw an error with return code 1.
         # The downside to this over checking for a timeout is that waiting
         # for 20 (n_chunks) errors takes time.

--- a/q2_mlab/tests/test_orchestrator.py
+++ b/q2_mlab/tests/test_orchestrator.py
@@ -1,0 +1,29 @@
+import unittest
+import os
+from q2_mlab import _orchestrate
+
+
+class OrchestratorTests((unittest.TestCase)):
+
+    def setUp(self):
+        self.TEST_DIR = os.path.split(__file__)[0]
+        self.dataset_file = os.path.join(
+            self.TEST_DIR, "data/table.qza"
+        )
+        self.metadata_file = os.path.join(
+            self.TEST_DIR, "data/sample-metadata-binary.tsv"
+        )
+
+    def testDryRun(self):
+        print(__file__)
+        print(os.getcwd())
+        _orchestrate(
+            dataset="imsms_test",
+            preparation="16S",
+            target="reported-antibiotic-usage",
+            algorithm="LinearSVC",
+            base_dir=self.TEST_DIR,
+            dataset_path=self.dataset_file,
+            metadata_path=self.metadata_file,
+            dry=True
+        )

--- a/q2_mlab/tests/test_orchestrator.py
+++ b/q2_mlab/tests/test_orchestrator.py
@@ -136,43 +136,44 @@ class OrchestratorTests(unittest.TestCase):
         completed_process = subprocess.run(
             f"{self.test_script}",
             shell=True,
-            timeout=1,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
         self.assertEqual(completed_process.returncode, 0)
+        print(completed_process)
 
         os.environ["PBS_ARRAYID"] = "50"
         completed_process = subprocess.run(
             f"{self.test_script}",
             shell=True,
-            timeout=1,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
         self.assertEqual(completed_process.returncode, 0)
+        print(completed_process)
 
     def testValidJobArrayID(self):
-        # Test valid array ids
-        # These should time out
-        with self.assertRaises(subprocess.TimeoutExpired):
-            os.environ["PBS_ARRAYID"] = "5"
-            completed_process = subprocess.run(
-                f"{self.test_script}",
-                shell=True,
-                timeout=2,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            print(completed_process)
+        # Since the metadata provided is not SampleData[Target], 
+        # we expect q2_mlab to throw an error with return code 1.
+        # The downside to this over checking for a timeout is that waiting
+        # for 20 (n_chunks) errors takes time.
 
-        with self.assertRaises(subprocess.TimeoutExpired):
-            os.environ["PBS_ARRAYID"] = "6"
-            completed_process = subprocess.run(
-                f"{self.test_script}",
-                shell=True,
-                timeout=2,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            print(completed_process)
+        os.environ["PBS_ARRAYID"] = "5"
+        completed_process = subprocess.run(
+            f"{self.test_script}",
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.assertEqual(completed_process.returncode, 1)
+        print(completed_process)
+
+        os.environ["PBS_ARRAYID"] = "6"
+        completed_process = subprocess.run(
+            f"{self.test_script}",
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.assertEqual(completed_process.returncode, 1)
+        print(completed_process)

--- a/q2_mlab/tests/test_orchestrator.py
+++ b/q2_mlab/tests/test_orchestrator.py
@@ -164,7 +164,6 @@ class OrchestratorTests(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-            print(completed_process)
 
         with self.assertRaises(subprocess.TimeoutExpired):
             os.environ["PBS_ARRAYID"] = "6"
@@ -175,4 +174,3 @@ class OrchestratorTests(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-            print(completed_process)

--- a/q2_mlab/tests/test_orchestrator.py
+++ b/q2_mlab/tests/test_orchestrator.py
@@ -50,6 +50,7 @@ class OrchestratorTests(unittest.TestCase):
             with open(self.test_script, "w") as out:
                 for line in keeplines:
                     out.write(line)
+                out.write("\n")
         subprocess.run(["chmod", "755", self.test_script])
 
     def tearDown(self):

--- a/q2_mlab/tests/test_orchestrator.py
+++ b/q2_mlab/tests/test_orchestrator.py
@@ -161,8 +161,8 @@ class OrchestratorTests(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        self.assertEqual(completed_process.returncode, 1)
         print(completed_process)
+        self.assertEqual(completed_process.returncode, 1)
 
         os.environ["PBS_ARRAYID"] = "6"
         completed_process = subprocess.run(
@@ -171,5 +171,5 @@ class OrchestratorTests(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        self.assertEqual(completed_process.returncode, 1)
         print(completed_process)
+        self.assertEqual(completed_process.returncode, 1)


### PR DESCRIPTION
Here we bypass the Click CLI for Orchestrator so we can access it in Python, and create a test suite to ensure orchestrator creates the necessary.

New features/formats in Orchestrator:
- Added tests
- exportable _orchestrate() function
- "dry" option in python and CLI to perform a dry run that doesn't generate any files.

Job script template:
- adds logic to check if the given job array id is greater than the maximum number of chunks/jobs to run for the given algorithm
