### PR TITLE
Orchestrator Doctor

### DIFF
--- a/q2_mlab/__init__.py
+++ b/q2_mlab/__init__.py
@@ -17,8 +17,7 @@ from .orchestrator import orchestrate_hyperparameter_search
 from .doctor import (
     doctor_hyperparameter_search,
     parse_info, 
-    get_uninserted_results,
-    get_inserted_results,
+    get_results,
     filter_duplicate_parameter_results
 )
 
@@ -33,8 +32,7 @@ __all__ = [
     "orchestrate_hyperparameter_search",
     "doctor_hyperparameter_search",
     "parse_info", 
-    "get_uninserted_results",
-    "get_inserted_results",
+    "get_results",
     "filter_duplicate_parameter_results",
     "ResultsDirectoryFormat",
     "ResultsFormat",

--- a/q2_mlab/__init__.py
+++ b/q2_mlab/__init__.py
@@ -14,6 +14,13 @@ from ._type import Target, Results
 from ._format import ResultsDirectoryFormat, ResultsFormat
 from ._parameters import ParameterGrids
 from .orchestrator import orchestrate_hyperparameter_search
+from .doctor import (
+    doctor_hyperparameter_search,
+    parse_info, 
+    get_uninserted_results,
+    get_inserted_results,
+    filter_duplicate_parameter_results
+)
 
 __version__ = get_versions()["version"]
 
@@ -24,6 +31,11 @@ __all__ = [
     "unit_benchmark",
     "_unit_benchmark",
     "orchestrate_hyperparameter_search",
+    "doctor_hyperparameter_search",
+    "parse_info", 
+    "get_uninserted_results",
+    "get_inserted_results",
+    "filter_duplicate_parameter_results",
     "ResultsDirectoryFormat",
     "ResultsFormat",
     "Target",

--- a/q2_mlab/__init__.py
+++ b/q2_mlab/__init__.py
@@ -16,6 +16,7 @@ from ._parameters import ParameterGrids
 from .orchestrator import orchestrate_hyperparameter_search
 from .doctor import (
     doctor_hyperparameter_search,
+    sort_result_artifact_filenames,
     parse_info, 
     get_results,
     filter_duplicate_parameter_results
@@ -31,6 +32,7 @@ __all__ = [
     "_unit_benchmark",
     "orchestrate_hyperparameter_search",
     "doctor_hyperparameter_search",
+    "sort_result_artifact_filenames",
     "parse_info", 
     "get_results",
     "filter_duplicate_parameter_results",

--- a/q2_mlab/_parameters.py
+++ b/q2_mlab/_parameters.py
@@ -60,7 +60,7 @@ class ParameterGrids:
             "alpha": [1e-3, 1e-2, 1e-1, 0.5, 0.9],
             "learning_rate": [3e-1, 2e-1, 1e-1, 5e-2],
             "n_estimators": n_estimators,
-            "criterion": ["friedman_mse", "mse" "mae"],
+            "criterion": ["friedman_mse", "mse", "mae"],
             "max_features": [None, "sqrt", "log2", 0.2, 0.4, 0.6, 0.8],
             "max_depth": max_depth,
             "random_state": random_state,
@@ -68,10 +68,9 @@ class ParameterGrids:
         },
         "GradientBoostingClassifier": {
             "loss": ["deviance", "exponential"],
-            "alpha": [1e-3, 1e-2, 1e-1, 0.5, 0.9],
             "learning_rate": [3e-1, 2e-1, 1e-1, 1e-2],
             "n_estimators": n_estimators,
-            "criterion": ["friedman_mse", "mse" "mae"],
+            "criterion": ["friedman_mse", "mse", "mae"],
             "max_features": [None, "sqrt", "log2", 0.2, 0.4, 0.6, 0.8],
             "max_depth": max_depth,
             "random_state": random_state,
@@ -244,6 +243,7 @@ class ParameterGrids:
         "RadialSVC": {
             "C": [1e-4, 1e-3, 1e-2, 1e-1, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7],
             "gamma": ["scale", "auto", 100, 10, 1, 1e-2, 1e-3, 1e-4, 1e-5],
+            "probability": [True],
         },
         "SigmoidSVR": {
             "C": [1e-4, 1e-3, 1e-2, 1e-1, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7],
@@ -255,6 +255,7 @@ class ParameterGrids:
             "C": [1e-4, 1e-3, 1e-2, 1e-1, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7],
             "gamma": ["scale", "auto", 100, 10, 1, 1e-2, 1e-3, 1e-4, 1e-5],
             "coef0": [0, 1, 10, 100],
+            "probability": [True],
         },
         "RidgeClassifier": [
             {
@@ -262,7 +263,7 @@ class ParameterGrids:
                 "fit_intercept": [True],
                 "normalize": [True, False],
                 "tol": [1e-1, 1e-2, 1e-3],
-                "solver": ["sparse_cg", "saga"],
+                "solver": ["sparse_cg"],
                 "random_state": random_state,
             },
             {
@@ -270,7 +271,7 @@ class ParameterGrids:
                 "fit_intercept": [False],
                 "normalize": [True, False],
                 "tol": [1e-1, 1e-2, 1e-3],
-                "solver": ["svd", "cholesky", "lsqr"],
+                "solver": ["cholesky", "lsqr", "saga"],
                 "random_state": random_state,
             },
         ],
@@ -352,110 +353,10 @@ class ParameterGrids:
         },
     }
 
-    reduced_ensemble_grids = {
-        "RandomForestClassifier": {
-            "n_estimators": [10, 100, 1000],
-            "criterion": ["gini"],
-            "max_features": ["sqrt", "log2", None, 0.4, 0.6],
-            "max_samples": [0.25, 0.5, 0.75, None],
-            "max_depth": [None, 10, 100],
-            "n_jobs": n_jobs,
-            "random_state": random_state,
-            "bootstrap": [True],
-        },
-        "RandomForestRegressor": {
-            "n_estimators": [10, 100, 1000],
-            "criterion": ["mse"],
-            "max_features": ["sqrt", "log2", None, 0.4, 0.6],
-            "max_samples": [0.25, 0.5, 0.75, None],
-            "max_depth": [None, 10, 100],
-            "n_jobs": n_jobs,
-            "random_state": random_state,
-            "bootstrap": [True],
-        },
-        "GradientBoostingRegressor": {
-            "loss": ["ls", "lad", "huber", "quantile"],
-            "alpha": [1e-3, 1e-1, 0.5, 0.9],
-            "learning_rate": [3e-1, 1e-1, 5e-2],
-            "n_estimators": [1000, 5000],
-            "criterion": ["mse"],
-            "max_features": [None, "sqrt", "log2", 0.4, 0.6],
-            "max_depth": [None, 10, 100],
-            "random_state": random_state,
-        },
-        "GradientBoostingClassifier": {
-            "loss": ["deviance", "exponential"],
-            "learning_rate": [3e-1, 1e-1, 5e-2],
-            "n_estimators": [1000, 5000],
-            "criterion": ["mse"],
-            "max_features": [None, "sqrt", "log2", 0.4, 0.6],
-            "max_depth": [None, 10, 100],
-            "random_state": random_state,
-        },
-        "XGBRegressor": {
-            "max_depth": [None, 10, 100],
-            "learning_rate": [3e-1, 2e-1, 1e-1, 5e-2],
-            "n_estimators": [5000],
-            "objective": ["reg:linear"],
-            "booster": ["gbtree"],
-            "gamma": [0],
-            "reg_alpha": [1e-3, 1e-1, 1],
-            "reg_lambda": [1e-3, 1e-1, 1],
-            "random_state": random_state,
-            "silent": [1],
-            "n_jobs": n_jobs,
-        },
-        "XGBClassifier": {
-            "max_depth": [None, 10, 100],
-            "learning_rate": [3e-1, 2e-1, 1e-1, 5e-2],
-            "n_estimators": [1000, 5000],
-            "objective": ["reg:linear"],
-            "booster": ["gbtree"],
-            "gamma": [0],
-            "reg_alpha": [1e-3, 1e-1, 1],
-            "reg_lambda": [1e-3, 1e-1, 1],
-            "random_state": random_state,
-            "silent": [1],
-            "n_jobs": n_jobs,
-        },
-        "ExtraTreesClassifier": {
-            "n_estimators": [5000],
-            "criterion": ["gini"],
-            "max_features": [None, "sqrt", "log2", 0.4, 0.6],
-            "max_samples": [0.25, 0.5, 0.75, None],
-            "max_depth": [None],
-            "n_jobs": n_jobs,
-            "random_state": random_state,
-            "bootstrap": [True],
-        },
-        "ExtraTreesRegressor": {
-            "n_estimators": [5000],
-            "criterion": ["mse"],
-            "max_features": [None, "sqrt", "log2", 0.4, 0.6],
-            "max_samples": [0.25, 0.5, 0.75, None],
-            "max_depth": [None],
-            "n_jobs": [-1],
-            "random_state": random_state,
-            "bootstrap": [True],
-        },
-    }
-
-    def get_size(algorithm, reduced=False):
-        if reduced:
-            grid = ParameterGrids.get_reduced(algorithm)
-        else:
-            grid = ParameterGrids.get(algorithm)
+    def get_size(algorithm):
+        grid = ParameterGrids.get(algorithm)
         size = len(list(ParameterGrid(grid)))
         return size
 
     def get(algorithm):
         return ParameterGrids.full_grids[algorithm]
-
-    def get_reduced(algorithm):
-        # Updates the full parameter grids with reduced grids for just
-        # the ensemble methods
-        fullgrid_shallow_copy = ParameterGrids.full_grids.copy()
-        fullgrid_shallow_copy.update(
-            ParameterGrids.reduced_ensemble_grids
-        )
-        return fullgrid_shallow_copy[algorithm]

--- a/q2_mlab/db/schema.py
+++ b/q2_mlab/db/schema.py
@@ -48,6 +48,7 @@ class ClassificationScore(Base, Score):
     F1 = Column(Float)
     PROB_CLASS_0 = Column(Float)
     PROB_CLASS_1 = Column(Float)
+    BALANCED_ACCURACY = Column(Float)
 
     parameters_id = Column(Integer, ForeignKey('parameters.id'))
 

--- a/q2_mlab/db/tests/test_db.py
+++ b/q2_mlab/db/tests/test_db.py
@@ -223,11 +223,13 @@ class DBTestCase(unittest.TestCase):
         results = pd.DataFrame([
             {
                 'CV_IDX': 0, 'RUNTIME': 2.3, 'PROB_CLASS_0': 0.502,
-                'PROB_CLASS_1': 0.498, 'AUPRC': 0.3, 'AUROC': 0.3, 'F1': 0.0
+                'ACCURACY': 0.309, 'PROB_CLASS_1': 0.498, 'AUPRC': 0.3, 
+                'AUROC': 0.3, 'F1': 0.0, 'BALANCED_ACCURACY': 0.409
             },
             {
                 'CV_IDX': 1, 'RUNTIME': 2.9, 'PROB_CLASS_0': 0.603,
-                'PROB_CLASS_1': 0.397, 'AUPRC': 0.4, 'AUROC': 0.5, 'F1': 0.0
+                'ACCURACY': 0.309, 'PROB_CLASS_1': 0.397, 'AUPRC': 0.4, 
+                'AUROC': 0.5, 'F1': 0.0, 'BALANCED_ACCURACY': 0.409
             },
         ])
         dataset = 'FINRISK'

--- a/q2_mlab/doctor.py
+++ b/q2_mlab/doctor.py
@@ -16,16 +16,16 @@ def parse_info(info_filepath):
 
 def get_results(results_dir):
     """
-    Scans the given directory and returns a list of filenames of all QIIME2 
-    Artifacts in the directory.
+    Scans the given directory and returns a list of filenames of all QIIME2
+    artifacts in the directory.
 
             Parameters:
-                    results_dir (str): The directory containing result Artifacts.
+                    results_dir (str): The directory containing result artifacts.
             Returns:
-                    artifact_filenames (List): List of the found Artifact filenames
+                    artifact_filenames (List): List of the found artifact filenames
     """
     if os.path.isdir(results_dir):
-        artifact_filenames =  [
+        artifact_filenames = [
             f.name for f in os.scandir(results_dir) if f.path.endswith(".qza")
         ]
     else:
@@ -39,7 +39,7 @@ def filter_duplicate_parameter_results(
     """
     From a sorted list of artifact filenames (sorted by parameter index),
     compare neighboring artifacts and if they are duplicate results on the same
-    parameter index, either ignore (delete=False) or delete (delete=True) the 
+    parameter index, either ignore (delete=False) or delete (delete=True) the
     older of the two duplicate results.
 
             Parameters:
@@ -87,7 +87,7 @@ def filter_duplicate_parameter_results(
         # Update current path
         curr_path = next_path
         curr_param_idx = next_param_idx
-    
+
     # Change working dir back
     os.chdir(prev_working_dir)
 

--- a/q2_mlab/doctor.py
+++ b/q2_mlab/doctor.py
@@ -9,9 +9,9 @@ def sort_result_artifact_filenames(list_of_artifact_filenames):
     """Sort the result artifact filenames
 
     Sorts the given list of result filenames by parameter index (assumed to be
-    the beginning of the filename, preceding an underscore e.g. 
+    the beginning of the filename, preceding an underscore e.g.
     ``00004_*.qza``)
-    
+
     Parameters
     ----------
     list_of_artifact_filenames : List
@@ -28,19 +28,20 @@ def sort_result_artifact_filenames(list_of_artifact_filenames):
 
     """
     sorted_artifact_filenames = sorted(
-        list_of_artifact_filenames,
-        key=lambda name: int(name.split('_')[0])
+        list_of_artifact_filenames, key=lambda name: int(name.split("_")[0])
     )
     return sorted_artifact_filenames
 
 
 def parse_info(info_filepath):
-    return pd.read_csv(info_filepath).to_dict('records')[0]
+    return pd.read_csv(info_filepath, skipinitialspace=True).to_dict(
+        "records"
+    )[0]
 
 
 def get_results(results_dir):
     """Get result artifact filenames
-    
+
     Scans the given directory and returns a list of filenames of all QIIME2
     artifacts in the directory.
 
@@ -68,7 +69,7 @@ def filter_duplicate_parameter_results(
     list_of_artifact_filenames, results_dir, delete=False
 ):
     """Filter out duplicate results on the same parameter set
-    
+
     From a sorted list of artifact filenames (sorted by parameter index),
     compare neighboring artifacts and if they are duplicate results on the same
     parameter index, either ignore (delete=False) or delete (delete=True) the
@@ -76,12 +77,12 @@ def filter_duplicate_parameter_results(
 
     Parameters
     ----------
-    list_of_artifact_filenames : List 
+    list_of_artifact_filenames : List
         A list of artifact filenames returned by get_results()
     results_dir : str
         The directory containing result artifacts.
     delete : bool, optional
-        Delete the duplicate results if ``True``, or ignore them if 
+        Delete the duplicate results if ``True``, or ignore them if
         ``False``.
 
     Returns
@@ -145,7 +146,7 @@ def doctor_hyperparameter_search(
     delete_duplicates=False,
 ):
     """Identify jobs to relaunch to generate missing result artifacts
-    
+
     Searches for the job description file for the experiment described by
     this function's parameters, searches through the files produced for
     missing results, and relaunches jobs necessary for completing those results.
@@ -156,7 +157,7 @@ def doctor_hyperparameter_search(
         Name of dataset.
     preparation : str
         Name of data type/preparation (e.g. 16S).
-    target : str 
+    target : str
         Name of the target variable in the metadata.
     algorithm : str
         Valid algorithm included in q2_mlab.
@@ -165,7 +166,7 @@ def doctor_hyperparameter_search(
     max_results : str, optional
         The maximum number of result artifacts to expect. Defaults to 1000.
     delete_duplicates : bool, optional
-        If ``True``, deletes the older of duplicate results on the same 
+        If ``True``, deletes the older of duplicate results on the same
         parameter id. Defaults to ``False`` where duplicate results are
         ignored.
 
@@ -237,9 +238,7 @@ def doctor_hyperparameter_search(
         )
 
     # Compute missing parameter indices:
-    expected_num_results = min(
-        max_results, info_dict["parameter_space_size"]
-    )
+    expected_num_results = min(max_results, info_dict["parameter_space_size"])
     expected_param_indices = set(range(1, expected_num_results + 1))
 
     all_filenames = inserted_filenames + uninserted_filenames
@@ -254,7 +253,7 @@ def doctor_hyperparameter_search(
     for missing_idx in missing_param_indices:
         # Identify which chunk to run:
         chunk_size = info_dict["chunk_size"]
-        missing_chunk = ((missing_idx-1) // chunk_size) + 1
+        missing_chunk = ((missing_idx - 1) // chunk_size) + 1
         chunks_to_rerun.add(missing_chunk)
 
     # Return command to re-run missing chunks

--- a/q2_mlab/doctor.py
+++ b/q2_mlab/doctor.py
@@ -32,7 +32,11 @@ def filter_duplicate_parameter_results(
     list_of_artifact_paths, results_dir, delete=False
 ):
     artifact_paths = list_of_artifact_paths.copy()
+
+    # Change working dirs
+    prev_working_dir = os.getcwd()
     os.chdir(results_dir)
+
     if len(artifact_paths) == 0:
         raise ValueError("There are no result artifacts to remove.")
     artifact_paths.sort()
@@ -62,6 +66,9 @@ def filter_duplicate_parameter_results(
         # Update current path
         curr_path = next_path
         curr_param_idx = next_param_idx
+    
+    # Change working dir back
+    os.chdir(prev_working_dir)
 
     return artifact_paths
 
@@ -131,7 +138,7 @@ def doctor_hyperparameter_search(
     uninserted_filenames = get_uninserted_results(results_dir)
     inserted_filenames = get_inserted_results(results_dir)
 
-    # TODO remove duplicate parameter indices
+    # Remove duplicate parameter indices
     if len(inserted_filenames) > 0:
         inserted_dir = os.path.join(results_dir, "inserted")
         inserted_filenames = filter_duplicate_parameter_results(

--- a/q2_mlab/doctor.py
+++ b/q2_mlab/doctor.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+import click
+import os
+from datetime import datetime
+
+
+def parse_info(info_filepath):
+    with open(info_filepath) as f:
+        lines = f.readlines()
+        info_dict = {
+            key.strip(): val.strip()
+            for key, val in zip(lines[0].split(","), lines[1].split(","))
+        }
+    return info_dict
+
+
+def get_uninserted_results(results_dir):
+    return [f.name for f in os.scandir(results_dir) if f.path.endswith(".qza")]
+
+
+def get_inserted_results(results_dir):
+    inserted_dir = os.path.join(results_dir, "inserted")
+    if not os.path.isdir(inserted_dir):
+        return []
+    else:
+        return [
+            f.name for f in os.scandir(inserted_dir) if f.path.endswith(".qza")
+        ]
+
+
+def filter_duplicate_parameter_results(
+    list_of_artifact_paths, results_dir, delete=False
+):
+    artifact_paths = list_of_artifact_paths.copy()
+    os.chdir(results_dir)
+    if len(artifact_paths) == 0:
+        raise ValueError("There are no result artifacts to remove.")
+    artifact_paths.sort()
+
+    curr_path = artifact_paths[0]
+    curr_param_idx = int(curr_path.split("_")[0])
+
+    for next_path in artifact_paths[1:]:
+        next_param_idx = int(next_path.split("_")[0])
+        if next_param_idx == curr_param_idx:
+            # Remove the older of the duplicate results
+            curr_path_time = datetime.fromtimestamp(
+                os.stat(curr_path).st_mtime
+            )
+            next_path_time = datetime.fromtimestamp(
+                os.stat(next_path).st_mtime
+            )
+            if curr_path_time < next_path_time:
+                artifact_paths.remove(curr_path)
+                if delete:
+                    os.remove(curr_path)
+            else:
+                artifact_paths.remove(next_path)
+                if delete:
+                    os.remove(next_path)
+                continue  # Do not update current_path
+        # Update current path
+        curr_path = next_path
+        curr_param_idx = next_param_idx
+
+    return artifact_paths
+
+
+def doctor_hyperparameter_search(
+    dataset,
+    preparation,
+    target,
+    algorithm,
+    base_dir,
+    max_results=1000,
+    delete_duplicates=False,
+):
+    """
+    Searches for the job description file for the experiment described by
+    this function's parameters, searches through the files produced for
+    missing results, and relaunches jobs necessary for completing those results.
+
+            Parameters:
+                    dataset (str): Name of dataset
+                    preparation (str): Name of data type/preparation (e.g. 16S)
+                    target (str): Name of the target variable in the metadata
+                    algorithm (str): Valid algorithm included in q2_mlab
+                    base_dir (str): The directory in which create the file structure.
+                    max_results (str): The maximum number of result artifacts to expect.
+                    delete_duplicates (bool): If True, deletes the older of duplicated results on the same parameter id.
+            Returns:
+                    summary (str): Summary of errors and jobs relaunched/to be relaunched
+    """
+    barnacle_out_dir = os.path.join(base_dir, dataset, "barnacle_output/")
+    results_dir = os.path.join(
+        base_dir, dataset, preparation, target, algorithm
+    )
+    output_script = os.path.join(
+        base_dir, dataset, "_".join([preparation, target, algorithm]) + ".sh"
+    )
+    info_doc = os.path.join(
+        base_dir,
+        dataset,
+        "_".join([preparation, target, algorithm]) + "_info.txt",
+    )
+
+    if not os.path.isdir(base_dir):
+        msg = "Cannot find directory with result file structure. This is typically generated with 'orchestrator'.\n"
+        raise FileNotFoundError(msg + base_dir + " does not exist.")
+
+    if not os.path.isdir(barnacle_out_dir):
+        msg = "Cannot find directory with job output. This is typically generated with 'orchestrator'.\n"
+        raise FileNotFoundError(msg + barnacle_out_dir + " does not exist.")
+
+    if not os.path.isdir(results_dir):
+        msg = "Cannot find directory with results. This is typically generated with 'qiime mlab unit_benchmark'\n"
+        raise FileNotFoundError(msg + results_dir + " does not exist.")
+
+    if not os.path.exists(output_script):
+        msg = "Cannot find the job script for this experiment. This is typically generated with 'orchestrator'\n"
+        raise FileNotFoundError(msg + output_script + " does not exist.")
+
+    if not os.path.exists(info_doc):
+        msg = "Cannot find info file for this experiment. This is typically generated with 'orchestrator'\n"
+        raise FileNotFoundError(msg + info_doc + " does not exist.")
+
+    # Parse info doc for expected result info
+    info_dict = parse_info(info_doc)
+
+    # Get all filenames in the results directory
+    uninserted_filenames = get_uninserted_results(results_dir)
+    inserted_filenames = get_inserted_results(results_dir)
+
+    # TODO remove duplicate parameter indices
+    if len(inserted_filenames) > 0:
+        inserted_dir = os.path.join(results_dir, "inserted")
+        inserted_filenames = filter_duplicate_parameter_results(
+            inserted_filenames, inserted_dir, delete=delete_duplicates
+        )
+    if len(uninserted_filenames) > 0:
+        uninserted_filenames = filter_duplicate_parameter_results(
+            uninserted_filenames, results_dir, delete=delete_duplicates
+        )
+
+    # Compute missing parameter indices:
+    expected_num_results = min(
+        max_results, int(info_dict["parameter_space_size"])
+    )
+    expected_param_indices = set(range(1, expected_num_results + 1))
+
+    all_filenames = inserted_filenames + uninserted_filenames
+    all_param_indices = {int(f.split("_")[0]) for f in all_filenames}
+
+    missing_param_indices = expected_param_indices - all_param_indices
+
+    if missing_param_indices == 0:
+        return None
+
+    chunks_to_rerun = set()
+    for missing_idx in missing_param_indices:
+        # Identify which chunk to run:
+        chunk_size = int(info_dict["chunk_size"])
+        missing_chunk = (missing_idx // chunk_size) + 1
+        chunks_to_rerun.add(missing_chunk)
+
+    # Return command to re-run missing chunks
+    cmd = f"qsub -t {','.join(map(str, chunks_to_rerun))} {output_script}"
+    print(cmd)
+    # subprocess.run(cmd)
+    return cmd
+
+
+@click.command()
+@click.argument("dataset")
+@click.argument("preparation")
+@click.argument("target")
+@click.argument("algorithm")
+@click.option(
+    "--base_dir",
+    "-b",
+    help="Directory to search for datasets in",
+    required=True,
+)
+@click.option(
+    "--max_results",
+    default=1000,
+    show_default=True,
+    help="Max number of result artifacts we expect per algorithm.",
+)
+@click.option(
+    "--delete_duplicates/--no_delete_duplicates",
+    default=False,
+    help="Do not remove duplicate result artifacts.",
+)
+def cli(
+    dataset,
+    preparation,
+    target,
+    algorithm,
+    base_dir,
+    max_results,
+    delete_duplicates,
+):
+    doctor_hyperparameter_search(
+        dataset=dataset,
+        preparation=preparation,
+        target=target,
+        algorithm=algorithm,
+        base_dir=base_dir,
+        max_results=max_results,
+        delete_duplicates=delete_duplicates,
+    )

--- a/q2_mlab/doctor.py
+++ b/q2_mlab/doctor.py
@@ -254,7 +254,7 @@ def doctor_hyperparameter_search(
     for missing_idx in missing_param_indices:
         # Identify which chunk to run:
         chunk_size = info_dict["chunk_size"]
-        missing_chunk = (missing_idx // chunk_size) + 1
+        missing_chunk = ((missing_idx-1) // chunk_size) + 1
         chunks_to_rerun.add(missing_chunk)
 
     # Return command to re-run missing chunks

--- a/q2_mlab/doctor.py
+++ b/q2_mlab/doctor.py
@@ -153,7 +153,7 @@ def doctor_hyperparameter_search(
 
     missing_param_indices = expected_param_indices - all_param_indices
 
-    if missing_param_indices == 0:
+    if len(missing_param_indices) == 0:
         return None
 
     chunks_to_rerun = set()

--- a/q2_mlab/doctor.py
+++ b/q2_mlab/doctor.py
@@ -4,6 +4,22 @@ import os
 from datetime import datetime
 
 
+def sort_result_artifact_filenames(list_of_artifact_filenames):
+    """
+    Sorts the given list of result filenames by parameter index (assumed to be
+    the beginning of the filename, preceding an underscore e.g. 00004_*.qza)
+
+            Parameters:
+                    list_of_artifact_filenames (List): A list of artifact filenames returned by get_results()
+            Returns:
+                    sorted_artifact_filenames (List): Sorted list of the found artifact filenames
+    """
+    temp_list = [(int(f.split("_")[0]), f) for f in list_of_artifact_filenames]
+    temp_list.sort()
+    sorted_artifact_filenames = [f[1] for f in temp_list]
+    return sorted_artifact_filenames
+
+
 def parse_info(info_filepath):
     with open(info_filepath) as f:
         lines = f.readlines()
@@ -58,7 +74,7 @@ def filter_duplicate_parameter_results(
 
     if len(artifact_filenames) == 0:
         raise ValueError("There are no result artifacts to remove.")
-    artifact_filenames.sort()
+    artifact_filenames = sort_result_artifact_filenames(artifact_filenames)
 
     curr_path = artifact_filenames[0]
     curr_param_idx = int(curr_path.split("_")[0])

--- a/q2_mlab/doctor.py
+++ b/q2_mlab/doctor.py
@@ -188,9 +188,10 @@ def doctor_hyperparameter_search(
     help="Max number of result artifacts we expect per algorithm.",
 )
 @click.option(
-    "--delete_duplicates/--no_delete_duplicates",
+    "--delete-duplicates/--no-delete-duplicates",
     default=False,
-    help="Do not remove duplicate result artifacts.",
+    show_default=True,
+    help="Remove duplicate result artifacts.",
 )
 def cli(
     dataset,

--- a/q2_mlab/learningtask.py
+++ b/q2_mlab/learningtask.py
@@ -110,7 +110,18 @@ class LearningTask(ABC):
             # so we can access that step's parameters.
             newparams = {prefix + key: val for key, val in self.params.items()}
             self.params = newparams
-        self.X = table.transpose().matrix_data
+        
+        # Convert to dense array for HistGradientBoosting
+        table_data = table.transpose().matrix_data
+        dense_only_algorithms = {
+            "HistGradientBoostingClassifier",
+            "HistGradientBoostingRegressor"
+        }
+        if algorithm in dense_only_algorithms:
+            self.X = table_data.todense()
+        else:
+            self.X = table_data
+
         self.metadata = metadata
         self.y = self.metadata.to_numpy()
         self.distance_matrix = distance_matrix

--- a/q2_mlab/orchestrator.py
+++ b/q2_mlab/orchestrator.py
@@ -269,11 +269,11 @@ def orchestrate_hyperparameter_search(
     help="Perform a dry run without writing files.",
 )
 @click.option(
-    "--table_path",
+    "--table-path",
     help="Path to feature table artifact from preprocess.",
 )
 @click.option(
-    "--metadata_path",
+    "--metadata-path",
     help="Path to target metadata artifact from preprocess.",
 )
 def cli(

--- a/q2_mlab/orchestrator.py
+++ b/q2_mlab/orchestrator.py
@@ -24,7 +24,7 @@ def orchestrate_hyperparameter_search(
     reduced=False,
     force=False,
     dry=False,
-    dataset_path=None,
+    table_path=None,
     metadata_path=None,
 ):
     """
@@ -40,7 +40,7 @@ def orchestrate_hyperparameter_search(
                     target (str): Name of the target variable in the metadata
                     algorithm (str): Valid algorithm included in q2_mlab
                     base_dir (str): The directory in which create the file structure.
-                    dataset_path (str): Specify exact path to dataset, if it cannot be assumed. Default=None
+                    table_path (str): Specify exact path to dataset, if it cannot be assumed. Default=None
                     metadata_path (str): Specify exact path to metadata, if it cannot be assumed. Default=None
                     repeats (int): Number of CV repeats. Default=3
                     ppn: Processors per node for job script. Default=1
@@ -96,8 +96,8 @@ def orchestrate_hyperparameter_search(
     FORCE = str(force).lower()
 
     # Use user-specified path, otherwise assume path from Preprocessing
-    if dataset_path:
-        TABLE_FP = dataset_path
+    if table_path:
+        TABLE_FP = table_path
     else:
         TABLE_FP = path.join(
             base_dir,
@@ -217,47 +217,64 @@ def orchestrate_hyperparameter_search(
     "--repeats",
     "-r",
     default=3,
+    show_default=True,
     help="Number of CV repeats",
 )
 @click.option(
     "--ppn",
     default=1,
+    show_default=True,
     help="Processors per node for job script",
 )
 @click.option(
     "--memory",
     default=32,
+    show_default=True,
     help="GB of memory for job script",
 )
 @click.option(
     "--wall",
     default=50,
+    show_default=True,
     help="Walltime in hours for job script",
 )
 @click.option(
     "--chunk_size",
     default=100,
+    show_default=True,
     help="Number of params to run in one job for job script",
 )
 @click.option(
     "--randomize/--no-randomize",
     default=True,
+    show_default=True,
     help="Randomly shuffle the order of the hyperparameter list",
 )
 @click.option(
     "--reduced/--no-reduced",
     default=False,
+    show_default=True,
     help="If a reduced parameter grid is available, run the reduced grid.",
 )
 @click.option(
     "--force/--no-force",
     default=False,
+    show_default=True,
     help="Overwrite existing results.",
 )
 @click.option(
     "--dry/--wet",
     default=False,
+    show_default=True,
     help="Perform a dry run without writing files.",
+)
+@click.option(
+    "--table_path",
+    help="Path to feature table artifact from preprocess.",
+)
+@click.option(
+    "--metadata_path",
+    help="Path to target metadata artifact from preprocess.",
 )
 def cli(
     dataset,
@@ -274,6 +291,8 @@ def cli(
     reduced,
     force,
     dry,
+    table_path,
+    metadata_path,
 ):
     orchestrate_hyperparameter_search(
         dataset=dataset,
@@ -290,6 +309,8 @@ def cli(
         reduced=reduced,
         force=force,
         dry=dry,
+        table_path=table_path,
+        metadata_path=metadata_path,
     )
 
 

--- a/q2_mlab/orchestrator.py
+++ b/q2_mlab/orchestrator.py
@@ -40,7 +40,7 @@ def orchestrate_hyperparameter_search(
                     target (str): Name of the target variable in the metadata
                     algorithm (str): Valid algorithm included in q2_mlab
                     base_dir (str): The directory in which create the file structure.
-                    table_path (str): Specify exact path to dataset, if it cannot be assumed. Default=None
+                    table_path (str): Specify exact path to feature table, if it cannot be assumed. Default=None
                     metadata_path (str): Specify exact path to metadata, if it cannot be assumed. Default=None
                     repeats (int): Number of CV repeats. Default=3
                     ppn: Processors per node for job script. Default=1

--- a/q2_mlab/orchestrator.py
+++ b/q2_mlab/orchestrator.py
@@ -53,7 +53,9 @@ def orchestrate_hyperparameter_search(
                     dry: Perform a dry run without writing files. Default=False
 
             Returns:
-                    binary_sum (str): Binary string of the sum of a and b
+                    output_script (str): Filepath to the created job script
+                    PARAMS_FP (str): Filepath to the created hyperparameter list
+                    info_doc (str): Filepath to the created job info text file
     """
     classifiers = set(RegressionTask.algorithms.keys())
     regressors = set(ClassificationTask.algorithms.keys())

--- a/q2_mlab/scripts/test_orchestrator_cli.sh
+++ b/q2_mlab/scripts/test_orchestrator_cli.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-orchestrator dset_test 16S reported-antibiotic-usage Lasso -b q2_mlab/tests/ --chunk_size 20 --dry
+mlab-orchestrator dset_test 16S reported-antibiotic-usage Lasso -b q2_mlab/tests/ --chunk_size 20 --dry

--- a/q2_mlab/tests/test_doctor.py
+++ b/q2_mlab/tests/test_doctor.py
@@ -6,6 +6,7 @@ import pandas as pd
 from q2_mlab import (
     orchestrate_hyperparameter_search,
     doctor_hyperparameter_search,
+    sort_result_artifact_filenames,
     parse_info,
     get_results,
     filter_duplicate_parameter_results,
@@ -115,6 +116,29 @@ class DoctorTests(unittest.TestCase):
         for file in os.listdir(self.results_dir):
             os.remove(os.path.join(self.results_dir, file))
         os.removedirs(self.results_dir)
+
+    def test_sort_result_artifact_filenames(self):
+        artifact_filenames = [
+            "00002_AlgorithmName_chunk_01.qza",
+            "0001_AlgorithmName_chunk_01.qza",
+            "000003_AlgorithmName_chunk_01.qza",
+            "004_AlgorithmName_chunk_01.qza",
+            "007_AlgorithmName_chunk_01.qza",
+            "0006_AlgorithmName_chunk_01.qza",
+            "5_AlgorithmName_chunk_01.qza",
+        ]
+        sorted_results = sort_result_artifact_filenames(artifact_filenames)
+
+        expected_artifact_filenames = [
+            "0001_AlgorithmName_chunk_01.qza",
+            "00002_AlgorithmName_chunk_01.qza",
+            "000003_AlgorithmName_chunk_01.qza",
+            "004_AlgorithmName_chunk_01.qza",
+            "5_AlgorithmName_chunk_01.qza",
+            "0006_AlgorithmName_chunk_01.qza",
+            "007_AlgorithmName_chunk_01.qza",
+        ]
+        self.assertListEqual(sorted_results, expected_artifact_filenames)
 
     def test_parse_info(self):
         info_dict = parse_info(self.run_info_fp)

--- a/q2_mlab/tests/test_doctor.py
+++ b/q2_mlab/tests/test_doctor.py
@@ -7,8 +7,7 @@ from q2_mlab import (
     orchestrate_hyperparameter_search,
     doctor_hyperparameter_search,
     parse_info,
-    get_uninserted_results,
-    get_inserted_results,
+    get_results,
     filter_duplicate_parameter_results,
 )
 
@@ -131,19 +130,20 @@ class DoctorTests(unittest.TestCase):
         self.assertDictEqual(info_dict, expected_dict)
 
     def test_get_uninserted_results(self):
-        results_list = get_uninserted_results(self.results_dir)
+        results_list = get_results(self.results_dir)
         for fname in results_list:
             self.assertTrue(fname.endswith(".qza"))
         self.assertEqual(len(results_list), 110)
 
     def test_get_inserted_results(self):
-        results_list = get_inserted_results(self.results_dir)
+        inserted_dir = os.path.join(self.results_dir, "inserted")
+        results_list = get_results(inserted_dir)
         for fname in results_list:
             self.assertTrue(fname.endswith(".qza"))
         self.assertEqual(len(results_list), 2)
 
     def test_filter_duplicate_parameter_results(self):
-        results_list = get_uninserted_results(self.results_dir)
+        results_list = get_results(self.results_dir)
         self.assertEqual(len(results_list), 110)
         self.assertTrue(
             set(self.newer_duplicate_results).issubset(set(results_list))
@@ -169,7 +169,7 @@ class DoctorTests(unittest.TestCase):
         )
         self.assertEqual(len(filtered_results_list), 106)
         # This should now not see any uninserted results.
-        results_list = get_uninserted_results(self.results_dir)
+        results_list = get_results(self.results_dir)
         self.assertEqual(len(results_list), 106)
         self.assertTrue(
             set(self.newer_duplicate_results).issubset(set(results_list))

--- a/q2_mlab/tests/test_doctor.py
+++ b/q2_mlab/tests/test_doctor.py
@@ -144,10 +144,10 @@ class DoctorTests(unittest.TestCase):
         info_dict = parse_info(self.run_info_fp)
         expected_dict = {
             "parameters_fp": self.params_fp,
-            "parameter_space_size": "112",
-            "chunk_size": "20",
-            "remainder": "12",
-            "n_chunks": "6",
+            "parameter_space_size": 112,
+            "chunk_size": 20,
+            "remainder": 12,
+            "n_chunks": 6,
         }
 
         self.assertDictEqual(info_dict, expected_dict)

--- a/q2_mlab/tests/test_doctor.py
+++ b/q2_mlab/tests/test_doctor.py
@@ -1,0 +1,198 @@
+import unittest
+import os
+import shutil
+import subprocess
+import pandas as pd
+from q2_mlab import (
+    orchestrate_hyperparameter_search,
+    doctor_hyperparameter_search,
+    parse_info,
+    get_uninserted_results,
+    get_inserted_results,
+    filter_duplicate_parameter_results,
+)
+
+
+class DoctorTests(unittest.TestCase):
+    def setUp(self):
+
+        self.TEST_DIR = os.path.split(__file__)[0]
+        self.dataset_file = os.path.join(self.TEST_DIR, "data/table.qza")
+
+        # The metadata doesn't matter here, as mlab will only accept
+        # SampleData[Target] artifacts from preprocessing.
+        self.metadata_file = os.path.join(
+            self.TEST_DIR, "data/sample-metadata.tsv"
+        )
+
+        self.dataset = "dset_test"
+        self.target = "reported-antibiotic-usage"
+        self.prep = "16S"
+        self.alg = "LinearSVR"  # Expect 112 parameters
+        self.chunk_size = 20
+
+        (
+            self.script_fp,
+            self.params_fp,
+            self.run_info_fp,
+        ) = orchestrate_hyperparameter_search(
+            dataset=self.dataset,
+            preparation=self.prep,
+            target=self.target,
+            algorithm=self.alg,
+            base_dir=self.TEST_DIR,
+            table_path=self.dataset_file,
+            metadata_path=self.metadata_file,
+            chunk_size=self.chunk_size,
+            dry=False,
+        )
+
+        self.results_dir = os.path.join(
+            self.TEST_DIR, self.dataset, self.prep, self.target, self.alg
+        )
+        # Populate results directory with older duplicate results (duplicate param_idx)
+        self.older_duplicate_results = [
+            "00000024_LinearSVR_chunk_888.qza",
+            "00000025_LinearSVR_chunk_888.qza",
+        ]
+        for dupe in self.older_duplicate_results:
+            open(os.path.join(self.results_dir, dupe), "a").close()
+        
+        # Populate results directory with empty results
+        remove_indices = {1, 21, 41, 101}  # Chunk 1, 2, 3, 6
+        param_indices = [i for i in range(1, 113) if i not in remove_indices]
+        for param_idx in param_indices:
+            chunk_num = (self.chunk_size // param_idx) + 1
+            param_idx_str = str(param_idx).zfill(8)
+            artifact_name = f"{param_idx_str}_{self.alg}_chunk_{chunk_num}.qza"
+            artifact_path = os.path.join(self.results_dir, artifact_name)
+            open(artifact_path, "a").close()
+        
+        # Add newer duplicate results 
+        self.newer_duplicate_results = [
+            "00000026_LinearSVR_chunk_999.qza",
+            "00000027_LinearSVR_chunk_999.qza",
+        ]
+        for dupe in self.newer_duplicate_results:
+            open(os.path.join(self.results_dir, dupe), "a").close()
+
+        # Move "inserted" results
+        inserted_dir = os.path.join(self.results_dir, "inserted")
+        os.mkdir(inserted_dir)
+        to_insert = [
+            "00000110_LinearSVR_chunk_1.qza",
+            "00000106_LinearSVR_chunk_1.qza",
+        ]
+        for artifact in to_insert:
+            uninserted_path = os.path.join(self.results_dir, artifact)
+            inserted_path = os.path.join(inserted_dir, artifact)
+            os.rename(uninserted_path, inserted_path)
+
+
+    def tearDown(self):
+
+        # Remove files we generated
+        files_generated = [
+            self.script_fp,
+            self.params_fp,
+            self.run_info_fp,
+        ]
+        for file in files_generated:
+            if file and os.path.exists(file):
+                os.remove(file)
+
+        # Remove the barnacle output directory
+        error_dir = os.path.join(
+            self.TEST_DIR, self.dataset, "barnacle_output/"
+        )
+        os.rmdir(error_dir)
+
+        # Remove the inserted directory
+        inserted_dir = os.path.join(self.results_dir, "inserted")
+        for file in os.listdir(inserted_dir):
+            os.remove(os.path.join(inserted_dir, file))
+        os.removedirs(inserted_dir)
+
+        # Remove parameter subset lists, results
+        for file in os.listdir(self.results_dir):
+            os.remove(os.path.join(self.results_dir, file))
+        os.removedirs(self.results_dir)
+
+    def test_parse_info(self):
+        info_dict = parse_info(self.run_info_fp)
+        expected_dict = {
+            "parameters_fp": self.params_fp,
+            "parameter_space_size": "112",
+            "chunk_size": "20",
+            "remainder": "12",
+            "n_chunks": "6",
+        }
+
+        self.assertDictEqual(info_dict, expected_dict)
+
+    def test_get_uninserted_results(self):
+        results_list = get_uninserted_results(self.results_dir)
+        for fname in results_list:
+            self.assertTrue(fname.endswith(".qza"))
+        self.assertEqual(len(results_list), 110)
+
+    def test_get_inserted_results(self):
+        results_list = get_inserted_results(self.results_dir)
+        for fname in results_list:
+            self.assertTrue(fname.endswith(".qza"))
+        self.assertEqual(len(results_list), 2)
+
+    def test_filter_duplicate_parameter_results(self):
+        results_list = get_uninserted_results(self.results_dir)
+        self.assertEqual(len(results_list), 110)
+        self.assertTrue(
+            set(self.newer_duplicate_results).issubset(set(results_list))
+        )
+
+        # Without actually removing duplicated files:
+        filtered_results_list = filter_duplicate_parameter_results(
+            results_list, self.results_dir, delete=False
+        )
+        self.assertEqual(len(filtered_results_list), 106)
+        
+        # Assert that we kept the newer duplicates,  discarded the older
+        self.assertTrue(
+            set(self.newer_duplicate_results).issubset(set(filtered_results_list))
+        )
+        self.assertFalse(
+            set(self.older_duplicate_results).issubset(set(filtered_results_list))
+        )
+
+        # With removing duplicated files:
+        filtered_results_list = filter_duplicate_parameter_results(
+            results_list, self.results_dir, delete=True
+        )
+        self.assertEqual(len(filtered_results_list), 106)
+        # This should now not see any uninserted results.
+        results_list = get_uninserted_results(self.results_dir)
+        self.assertEqual(len(results_list), 106)
+        self.assertTrue(
+            set(self.newer_duplicate_results).issubset(set(results_list))
+        )
+        self.assertFalse(
+            set(self.older_duplicate_results).issubset(set(results_list))
+        )
+
+
+    def test_doctor_hyperparameter_search(self):
+        cmd = doctor_hyperparameter_search(
+            dataset=self.dataset, 
+            preparation=self.prep, 
+            target=self.target, 
+            algorithm=self.alg, 
+            base_dir=self.TEST_DIR, 
+            max_results=1000,
+            delete_duplicates=False
+        )
+
+        self.assertEqual(
+            cmd,
+            f"qsub -t 1,2,3,6 {self.script_fp}"
+        )
+
+

--- a/q2_mlab/tests/test_doctor.py
+++ b/q2_mlab/tests/test_doctor.py
@@ -150,7 +150,23 @@ class DoctorTests(unittest.TestCase):
             "remainder": 12,
             "n_chunks": 6,
         }
+        self.assertDictEqual(info_dict, expected_dict)
 
+        with open("temp_info.txt", "w") as f:
+            f.write(
+                "parameters_fp, parameter_space_size, chunk_size, remainder, "
+                + "n_chunks\n"
+                + "./sol/MG/bmi_v2/alg/alg_params.txt, 5580, 20, 0, 279"
+            )
+        info_dict = parse_info("temp_info.txt")
+        os.remove("temp_info.txt")
+        expected_dict = {
+            "parameters_fp": "./sol/MG/bmi_v2/alg/alg_params.txt",
+            "parameter_space_size": 5580,
+            "chunk_size": 20,
+            "remainder": 0,
+            "n_chunks": 279,
+        }
         self.assertDictEqual(info_dict, expected_dict)
 
     def test_get_uninserted_results(self):
@@ -218,7 +234,6 @@ class DoctorTests(unittest.TestCase):
         )
 
         self.assertEqual(cmd, f"qsub -t 1,2,3,6 {self.script_fp}")
-    
 
     def test_doctor_with_all_missing_results(self):
 
@@ -247,7 +262,7 @@ class DoctorTests(unittest.TestCase):
             max_results=1000,
             delete_duplicates=False,
         )
-        expected_chunks = ",".join([str(i) for i in range(1,51)])
+        expected_chunks = ",".join([str(i) for i in range(1, 51)])
         self.assertEqual(cmd, f"qsub -t {expected_chunks} {this_script_fp}")
 
         # Remove files we generated

--- a/q2_mlab/tests/test_doctor.py
+++ b/q2_mlab/tests/test_doctor.py
@@ -56,7 +56,7 @@ class DoctorTests(unittest.TestCase):
         ]
         for dupe in self.older_duplicate_results:
             open(os.path.join(self.results_dir, dupe), "a").close()
-        
+
         # Populate results directory with empty results
         remove_indices = {1, 21, 41, 101}  # Chunk 1, 2, 3, 6
         param_indices = [i for i in range(1, 113) if i not in remove_indices]
@@ -66,8 +66,8 @@ class DoctorTests(unittest.TestCase):
             artifact_name = f"{param_idx_str}_{self.alg}_chunk_{chunk_num}.qza"
             artifact_path = os.path.join(self.results_dir, artifact_name)
             open(artifact_path, "a").close()
-        
-        # Add newer duplicate results 
+
+        # Add newer duplicate results
         self.newer_duplicate_results = [
             "00000026_LinearSVR_chunk_999.qza",
             "00000027_LinearSVR_chunk_999.qza",
@@ -86,7 +86,6 @@ class DoctorTests(unittest.TestCase):
             uninserted_path = os.path.join(self.results_dir, artifact)
             inserted_path = os.path.join(inserted_dir, artifact)
             os.rename(uninserted_path, inserted_path)
-
 
     def tearDown(self):
 
@@ -154,13 +153,17 @@ class DoctorTests(unittest.TestCase):
             results_list, self.results_dir, delete=False
         )
         self.assertEqual(len(filtered_results_list), 106)
-        
+
         # Assert that we kept the newer duplicates,  discarded the older
         self.assertTrue(
-            set(self.newer_duplicate_results).issubset(set(filtered_results_list))
+            set(self.newer_duplicate_results).issubset(
+                set(filtered_results_list)
+            )
         )
         self.assertFalse(
-            set(self.older_duplicate_results).issubset(set(filtered_results_list))
+            set(self.older_duplicate_results).issubset(
+                set(filtered_results_list)
+            )
         )
 
         # With removing duplicated files:
@@ -178,21 +181,15 @@ class DoctorTests(unittest.TestCase):
             set(self.older_duplicate_results).issubset(set(results_list))
         )
 
-
     def test_doctor_hyperparameter_search(self):
         cmd = doctor_hyperparameter_search(
-            dataset=self.dataset, 
-            preparation=self.prep, 
-            target=self.target, 
-            algorithm=self.alg, 
-            base_dir=self.TEST_DIR, 
+            dataset=self.dataset,
+            preparation=self.prep,
+            target=self.target,
+            algorithm=self.alg,
+            base_dir=self.TEST_DIR,
             max_results=1000,
-            delete_duplicates=False
+            delete_duplicates=False,
         )
 
-        self.assertEqual(
-            cmd,
-            f"qsub -t 1,2,3,6 {self.script_fp}"
-        )
-
-
+        self.assertEqual(cmd, f"qsub -t 1,2,3,6 {self.script_fp}")

--- a/q2_mlab/tests/test_orchestrator.py
+++ b/q2_mlab/tests/test_orchestrator.py
@@ -33,7 +33,7 @@ class OrchestratorTests(unittest.TestCase):
             target=self.target,
             algorithm=self.alg,
             base_dir=self.TEST_DIR,
-            dataset_path=self.dataset_file,
+            table_path=self.dataset_file,
             metadata_path=self.metadata_file,
             chunk_size=20,
             dry=False,
@@ -92,7 +92,7 @@ class OrchestratorTests(unittest.TestCase):
             target=target,
             algorithm=alg,
             base_dir=self.TEST_DIR,
-            dataset_path=self.dataset_file,
+            table_path=self.dataset_file,
             metadata_path=self.metadata_file,
             dry=True,
         )

--- a/q2_mlab/tests/test_parameters.py
+++ b/q2_mlab/tests/test_parameters.py
@@ -116,11 +116,11 @@ class ParameterGridsTests(unittest.TestCase):
             n_samples=16, n_features=4, task=Task.CLASSIFICATION,
         )
 
-    # def test_coverage(self):
-    #     self.assertCountEqual(
-    #         list(ParameterGrids.full_grids.keys()),
-    #         self.classification_algorithms+self.regression_algorithms
-    #     )
+    def test_coverage(self):
+        self.assertCountEqual(
+            list(ParameterGrids.full_grids.keys()),
+            self.classification_algorithms+self.regression_algorithms
+        )
 
     def test_regression_param_grids(self, algorithms=None):
         if algorithms is None:

--- a/q2_mlab/tests/test_parameters.py
+++ b/q2_mlab/tests/test_parameters.py
@@ -58,7 +58,7 @@ def create_synthetic_data(
 class ParameterGridsTests(unittest.TestCase):
 
     regression_algorithms = [
-        Ensemble
+        # Ensemble
         "RandomForestRegressor",
         "ExtraTreesRegressor",
         # Boosting

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
     url="https://qiime2.org",
     entry_points={
         'qiime2.plugins': ['q2-mlab=q2_mlab.plugin_setup:plugin'],
-        'console_scripts': ['orchestrator=q2_mlab.orchestrator:cli',
+        'console_scripts': ['mlab-orchestrator=q2_mlab.orchestrator:cli',
+                            'mlab-doctor=q2_mlab.doctor:cli',
                             'mlab-db=q2_mlab.db.cli:mlab_db',
                             'mlab-plotting=q2_mlab.plotting.app:mlab_plotting',
                             ],


### PR DESCRIPTION
This PR adds a doctor to check up on the status of result artifacts for a given configuration (dataset, prep, target, algorithm) and returns a command re-run jobs to generate missing result artifacts.
It takes the same arguments as mlab-orchestrator:
`mlab-orchestrator [OPTIONS] DATASET PREPARATION TARGET ALGORITHM`
`mlab-doctor [OPTIONS] DATASET PREPARATION TARGET ALGORITHM`
and outputs one line per qsub command to re-run:
 
```
qsub -t 1 ./processed/finrisk/16S_bmi_obese_RadialSVC.sh
qsub -t 1,2,3,4 ./processed/finrisk/16S_bmi_obese_SigmoidSVC.sh
qsub -t 1,2,3,4,5,6 ./processed/finrisk/16S_bmi_obese_HistGradientBoostingClassifier.sh
qsub -t 9,10,5 ./processed/finrisk/16S_bmi_obese_MLPClassifier.sh
...
```
For my usage I've been redirecting this output to a shell script so I can submit several batches at once.


This PR also includes some changes to allow classification.

- Adds balanced accuracy rate to the database's classificationscore schema.

Improvements to fix parameter set definitions for some classification algorithms:

- GradientBoostingClassifier : removed 'alpha' (not accepted)
- RadialSVC and Sigmoid SVC: set probability=True (default is False) to ensure we can use predict_proba() for class probabilities
- RidgeClassifier: Moved around incompatible solvers that were giving runtime errors
- HistGradientBoostingClassifier: Dense data required, added check to convert data to dense matrix in learningtask.py 
- Removes the "reduced" ensemble grids from parameters.py and tests, since maintaining two conflicting sets of parameters for some algorithms caused the above errors to slip by, and the reduced grids aren't essential for speeding up tests.

And unifies the CLI by changing the `orchestrator` command to `mlab-orchestrator`:
```
                             'mlab-orchestrator=q2_mlab.orchestrator:cli',
                             'mlab-doctor=q2_mlab.doctor:cli',
```


